### PR TITLE
Unngå race-conditions som fører til at det blir opprettet to saker på samme periode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,14 @@
         <version>2.0.5.RELEASE</version>
     </parent>
 
+    <repositories>
+        <repository>
+            <id>maven-releases</id>
+            <name>NAV Internal Repository</name>
+            <url>https://repo.adeo.no/repository/maven-releases/</url>
+        </repository>
+    </repositories>
+
     <distributionManagement>
         <repository>
             <id>maven-releases</id>

--- a/src/test/java/no/nav/syfo/consumer/mq/InntektsmeldingConsumerTest.java
+++ b/src/test/java/no/nav/syfo/consumer/mq/InntektsmeldingConsumerTest.java
@@ -27,6 +27,16 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class InntektsmeldingConsumerTest {
+    private static String inputPayload = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+            "  <ns5:forsendelsesinformasjon xmlns:ns5=\"http://nav.no/melding/virksomhet/dokumentnotifikasjon/v1\" " +
+            "    xmlns:ns2=\"http://nav.no/melding/virksomhet/dokumentforsendelse/v1\" " +
+            "    xmlns:ns4=\"http://nav.no/dokmot/jms/reply\" " +
+            "    xmlns:ns3=\"http://nav.no.dokmot/jms/viderebehandling\">" +
+            "  <arkivId>arkivId</arkivId>" +
+            "  <arkivsystem>JOARK</arkivsystem>" +
+            "  <tema>SYK</tema>" +
+            "  <behandlingstema>ab0061</behandlingstema>" +
+            "</ns5:forsendelsesinformasjon>";
 
     @Mock
     private Metrikk metrikk;
@@ -63,17 +73,7 @@ public class InntektsmeldingConsumerTest {
         when(saksbehandlingService.behandleInntektsmelding(any(), anyString())).thenReturn("saksId");
 
         ActiveMQTextMessage message = new ActiveMQTextMessage();
-        message.setText("" +
-                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
-                "  <ns5:forsendelsesinformasjon xmlns:ns5=\"http://nav.no/melding/virksomhet/dokumentnotifikasjon/v1\" " +
-                "    xmlns:ns2=\"http://nav.no/melding/virksomhet/dokumentforsendelse/v1\" " +
-                "    xmlns:ns4=\"http://nav.no/dokmot/jms/reply\" " +
-                "    xmlns:ns3=\"http://nav.no.dokmot/jms/viderebehandling\">" +
-                "  <arkivId>arkivId</arkivId>" +
-                "  <arkivsystem>JOARK</arkivsystem>" +
-                "  <tema>SYK</tema>" +
-                "  <behandlingstema>ab0061</behandlingstema>" +
-                "</ns5:forsendelsesinformasjon>");
+        message.setText(inputPayload);
         inntektsmeldingConsumer.listen(message);
 
         verify(saksbehandlingService).behandleInntektsmelding(any(), anyString());
@@ -89,17 +89,7 @@ public class InntektsmeldingConsumerTest {
                 .build());
 
         ActiveMQTextMessage message = new ActiveMQTextMessage();
-        message.setText("" +
-                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
-                "  <ns5:forsendelsesinformasjon xmlns:ns5=\"http://nav.no/melding/virksomhet/dokumentnotifikasjon/v1\" " +
-                "    xmlns:ns2=\"http://nav.no/melding/virksomhet/dokumentforsendelse/v1\" " +
-                "    xmlns:ns4=\"http://nav.no/dokmot/jms/reply\" " +
-                "    xmlns:ns3=\"http://nav.no.dokmot/jms/viderebehandling\">" +
-                "  <arkivId>arkivId</arkivId>" +
-                "  <arkivsystem>JOARK</arkivsystem>" +
-                "  <tema>SYK</tema>" +
-                "  <behandlingstema>ab0061</behandlingstema>" +
-                "</ns5:forsendelsesinformasjon>");
+        message.setText(inputPayload);
         inntektsmeldingConsumer.listen(message);
 
         verify(saksbehandlingService, never()).behandleInntektsmelding(any(), anyString());

--- a/src/test/java/no/nav/syfo/consumer/ws/JournalConsumerTest.java
+++ b/src/test/java/no/nav/syfo/consumer/ws/JournalConsumerTest.java
@@ -76,9 +76,11 @@ public class JournalConsumerTest {
         assertThat(inntektsmelding.getArbeidsgiverOrgnummer().isPresent()).isTrue();
         assertThat(inntektsmelding.getArbeidsgiverPrivat().isPresent()).isFalse();
     }
-
     public static String inntektsmeldingArbeidsgiver(List<Periode> perioder) {
+        return inntektsmeldingArbeidsgiver(perioder, "fnr");
+    }
 
+    public static String inntektsmeldingArbeidsgiver(List<Periode> perioder, String fnr) {
         return "<ns6:melding xmlns:ns6=\"http://seres.no/xsd/NAV/Inntektsmelding_M/20180924\">" +
                 "    <ns6:Skjemainnhold>" +
                 "        <ns6:ytelse>Sykepenger</ns6:ytelse>" +
@@ -90,7 +92,7 @@ public class JournalConsumerTest {
                 "                <ns6:telefonnummer>81549300</ns6:telefonnummer>" +
                 "            </ns6:kontaktinformasjon>" +
                 "        </ns6:arbeidsgiver>" +
-                "        <ns6:arbeidstakerFnr>fnr</ns6:arbeidstakerFnr>" +
+                "        <ns6:arbeidstakerFnr>" + fnr + "</ns6:arbeidstakerFnr>" +
                 "        <ns6:naerRelasjon>false</ns6:naerRelasjon>" +
                 "        <ns6:arbeidsforhold>" +
                 "            <ns6:foersteFravaersdag>2019-02-01</ns6:foersteFravaersdag>" +


### PR DESCRIPTION
Denne patchen tar i bruk en striped lock for å unngå at fler meldinger blir prosessert parallelt på samme bruker