### PR TITLE
Increase poll duration in UtsattOppgaveKafkaClient

### DIFF
--- a/src/main/kotlin/no/nav/syfo/integration/kafka/UtsattOppgaveKafkaClient.kt
+++ b/src/main/kotlin/no/nav/syfo/integration/kafka/UtsattOppgaveKafkaClient.kt
@@ -38,7 +38,7 @@ class UtsattOppgaveKafkaClient(props: Map<String, Any>,
         }
 
         try {
-            val records : ConsumerRecords<String, String>? = consumer.poll(Duration.ofMillis(1000))
+            val records : ConsumerRecords<String, String>? = consumer.poll(Duration.ofSeconds(10))
             val payloads = records?.map { it.value() }
             payloads.let {  currentBatch = it!! }
 

--- a/src/main/kotlin/no/nav/syfo/integration/kafka/UtsattOppgaveKafkaClient.kt
+++ b/src/main/kotlin/no/nav/syfo/integration/kafka/UtsattOppgaveKafkaClient.kt
@@ -38,7 +38,7 @@ class UtsattOppgaveKafkaClient(props: Map<String, Any>,
         }
 
         try {
-            val records : ConsumerRecords<String, String>? = consumer.poll(Duration.ofMillis(100))
+            val records : ConsumerRecords<String, String>? = consumer.poll(Duration.ofMillis(1000))
             val payloads = records?.map { it.value() }
             payloads.let {  currentBatch = it!! }
 


### PR DESCRIPTION
Denne øker poll-duration fra 100ms => 10s i UtsattOppgaveKafkaClient.

Da kjører testene lokalt og i GitHub actions igjennom.

For å fremprovosere feilmelding lokalt:
```sh
# Start med en clean kafka og database
$ docker rm -f local_spinn_db_1 local_spinn_kafka_1 && cd docker/local && docker-compose up -d && cd ../..

# Denne gir feilmelding ved første kjøring
$ ./gradlew slowTests
no.nav.syfo.slowtests.kafka.UtsattOppgaveKafkaConsumerTest > Skal lese utsattoppgave() FAILED
    org.opentest4j.AssertionFailedError:
    Expecting:
     <0>
    to be equal to:
     <1>
    but was not.
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at no.nav.syfo.slowtests.kafka.UtsattOppgaveKafkaConsumerTest.Skal lese utsattoppgave(UtsattOppgaveKafkaConsumerTest.kt:54)
```

For feilsøking lokalt
```sh
# Finne kjørende docker containere
> docker ps
CONTAINER ID   IMAGE               COMMAND                  CREATED          STATUS          PORTS                                            NAMES
7c619c199824   local_spinn_kafka   "supervisord -n"         21 minutes ago   Up 21 minutes   0.0.0.0:2181->2181/tcp, 0.0.0.0:9092->9092/tcp   local_spinn_kafka_1
cad8240a928a   local_spinn_db      "docker-entrypoint.s…"   21 minutes ago   Up 21 minutes   0.0.0.0:5432->5432/tcp                           local_spinn_db_1

# Gå inn i en kjørende container
> docker exec -it local_spinn_kafka_1 /bin/bash

# Se kafka topics
root@7c619c199824> ./opt/kafka_2.13-2.7.0/bin/kafka-topics.sh --list --zookeeper localhost:2181
__consumer_offsets
test1

# evt se direkte
> docker exec local_spinn_kafka_1 /opt/kafka_2.13-2.7.0/bin/kafka-topics.sh --list --zookeeper localhost:2181
__consumer_offsets
test1

# Se informasjon om topic "test1"
> docker exec local_spinn_kafka_1 /opt/kafka_2.13-2.7.0/bin/kafka-topics.sh --describe --topic test1 --zookeeper localhost:2181
Topic: test1	PartitionCount: 1	ReplicationFactor: 1	Configs:
	Topic: test1	Partition: 0	Leader: 0	Replicas: 0	Isr: 0

# Les alle meldinger fra topic "test1"
> docker exec local_spinn_kafka_1 /opt/kafka_2.13-2.7.0/bin/kafka-console-consumer.sh --topic test1 --from-beginning --bootstrap-server localhost:9092
```