### PR TITLE
Sjekk om listen er tom først

### DIFF
--- a/src/main/kotlin/no/nav/syfo/repository/UtsattOppgaveRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/repository/UtsattOppgaveRepository.kt
@@ -60,7 +60,11 @@ class UtsattOppgaveRepositoryImp(private val ds: DataSource) : UtsattOppgaveRepo
             val res = it.prepareStatement(findByInnteksmeldingId).apply {
                 setString(1, inntektsmeldingId)
             }.executeQuery()
-            return resultLoop(res, inntektsmeldinger).first()
+            val list: ArrayList<UtsattOppgaveEntitet> = resultLoop(res, inntektsmeldinger)
+            if (list.isEmpty()) {
+                return null
+            }
+            return list.first()
         }
     }
 


### PR DESCRIPTION
Legger inn sjekk for å unngå å få at jobbene feiler pga datalisten er tom:

"Jobb fad1a804-2af3-4b33-a679-ed33df861bcb feilet, forsøker igjen 2022-01-26T16:05:26.045280. "

Stacktrace

`java.util.NoSuchElementException: List is empty. 	at kotlin.collections.CollectionsKt___CollectionsKt.first(_Collections.kt:212) 	at no.nav.syfo.repository.UtsattOppgaveRepositoryImp.findByInntektsmeldingId(UtsattOppgaveRepository.kt:63) 	at `