### PR TITLE
Logger når vi ikke finner inntektsmelding med arkivref

### DIFF
--- a/src/main/kotlin/no/nav/syfo/repository/InntektsmeldingRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/repository/InntektsmeldingRepository.kt
@@ -82,7 +82,7 @@ class InntektsmeldingRepositoryImp(
             val res = it.prepareStatement(sqlQuery).apply {
                 setString(1, arkivRefereanse)
             }.executeQuery()
-            result = resultLoop(res, inntektsmeldinger).first()
+            result = resultLoop(res, inntektsmeldinger).firstOrNull()!!
         }
         result.arbeidsgiverperioder = finnAgpForIm(result.uuid).toMutableList()
         return result

--- a/src/main/kotlin/no/nav/syfo/utsattoppgave/UtsattOppgaveService.kt
+++ b/src/main/kotlin/no/nav/syfo/utsattoppgave/UtsattOppgaveService.kt
@@ -97,6 +97,9 @@ fun opprettOppgaveIGosys(
     val behandlendeEnhet = behandlendeEnhetConsumer.hentBehandlendeEnhet(utsattOppgave.fnr, utsattOppgave.inntektsmeldingId)
     val gjelderUtland = (SYKEPENGER_UTLAND == behandlendeEnhet)
     val imEntitet = inntektsmeldingRepository.findByArkivReferanse(utsattOppgave.arkivreferanse)
+    if (imEntitet == null) {
+        log.error("Inntektsmelding med arkivreferanse ${utsattOppgave.arkivreferanse} ikke funnet")
+    }
     val inntektsmelding = om.readValue<Inntektsmelding>(imEntitet.data!!)
     val behandlingsTema = finnBehandlingsTema(inntektsmelding)
     log.info("Fant enhet $behandlendeEnhet for ${utsattOppgave.arkivreferanse}")


### PR DESCRIPTION
Returnerer `firstOrNull!!` fra `findByArkivReferanse()`.
Se [issue 253](https://github.com/navikt/syfoinntektsmelding/issues/253)

Usikker på hvilke tilfeller hvor inntektsmelding ikke skal finnes i tabellen?
Må sjekker mer opp.

Hvis den skal takle at inntektsmelding eksisterer, kan en løsning kan være å sette en default verdi i `utsattOppgaveService.kt` f.eks. eller noe lignende:
```kt
   ...
    val imEntitet = inntektsmeldingRepository.findByArkivReferanse(utsattOppgave.arkivreferanse)
    var behandlingsTema = BehandlingsTema.IKKE_REFUSJON
    if (imEntitet != null) {
        val inntektsmelding = om.readValue<Inntektsmelding>(imEntitet.data!!)
        behandlingsTema = finnBehandlingsTema(inntektsmelding)
    }
    ...
```