### PR TITLE
Bruk tidligere felles bibliotek 2022.01.18-08-47-f6aa0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,7 +76,7 @@ dependencies {
     implementation("no.nav.syfo.sm:syfosm-common-networking:2019.09.25-05-44-08e26429f4e37cd57d99ba4d39fc74099a078b97")
     implementation("no.nav:vault-jdbc:1.3.7")
     implementation("no.nav.common:log:2.2022.02.18_14.38-8d8bb494bd41")
-    implementation("no.nav.helsearbeidsgiver:helse-arbeidsgiver-felles-backend:2022.03.23-10-47-91ba1")
+    implementation("no.nav.helsearbeidsgiver:helse-arbeidsgiver-felles-backend:2022.01.18-08-47-f6aa0")
     implementation("no.nav.security:token-client-core:$tokenSupportVersion")
     implementation("no.nav.security:token-validation-ktor:$tokenSupportVersion")
     implementation("no.nav.security:mock-oauth2-server:$mockOAuth2ServerVersion")


### PR DESCRIPTION
Jeg oppgraderte fellesbiblioteket men da fant den ikke lenger klassen KubernetesProbeManager. Ruller tilbake