### PR TITLE
Skape bakoverkompatibilitet for gammel versjon av Inntektsmelding

### DIFF
--- a/src/main/kotlin/no/nav/syfo/domain/InngaaendeJournal.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/InngaaendeJournal.kt
@@ -15,6 +15,7 @@ enum class JournalStatus {
     MOTTATT, // Tidligere: MIDLERTIDIG
     UKJENT, // Tidligere: ANNET
     FERDIGSTILT, // Tidligere: ENDELIG
+    MIDLERTIDIG,
     UTGAAR,
     JOURNALFOERT,
     EKSPEDERT,

--- a/src/main/kotlin/no/nav/syfo/domain/inntektsmelding/Inntektsmelding.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/inntektsmelding/Inntektsmelding.kt
@@ -15,7 +15,7 @@ data class Inntektsmelding(
     val arbeidsforholdId: String? = null,
     val journalpostId: String,
     val arsakTilInnsending: String,
-    val journalStatus: JournalStatus,
+    var journalStatus: JournalStatus,
     val arbeidsgiverperioder: List<Periode> = emptyList(),
     val beregnetInntekt: BigDecimal? = null,
     val refusjon: Refusjon = Refusjon(),

--- a/src/main/kotlin/no/nav/syfo/mapping/InntektsmeldingDtoMapper.kt
+++ b/src/main/kotlin/no/nav/syfo/mapping/InntektsmeldingDtoMapper.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.mapping
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import no.nav.syfo.domain.JournalStatus
 import no.nav.syfo.domain.Periode
 import no.nav.syfo.domain.inntektsmelding.Inntektsmelding
 import no.nav.syfo.dto.ArbeidsgiverperiodeEntitet
@@ -20,7 +21,11 @@ fun toInntektsmeldingEntitet(inntektsmelding: Inntektsmelding): InntektsmeldingE
 }
 
 fun toInntektsmelding(inntektsmeldingEntitet: InntektsmeldingEntitet, objectMapper: ObjectMapper): Inntektsmelding {
-    return objectMapper.readValue(inntektsmeldingEntitet.data, Inntektsmelding::class.java)
+    var im = objectMapper.readValue(inntektsmeldingEntitet.data, Inntektsmelding::class.java)
+    if (im.journalStatus == JournalStatus.MIDLERTIDIG){
+        im.journalStatus = JournalStatus.MOTTATT
+    }
+    return im
 }
 
 fun mapPerioder(perioder: List<ArbeidsgiverperiodeEntitet>): List<Periode> {

--- a/src/main/kotlin/no/nav/syfo/mapping/InntektsmeldingDtoMapper.kt
+++ b/src/main/kotlin/no/nav/syfo/mapping/InntektsmeldingDtoMapper.kt
@@ -22,7 +22,7 @@ fun toInntektsmeldingEntitet(inntektsmelding: Inntektsmelding): InntektsmeldingE
 
 fun toInntektsmelding(inntektsmeldingEntitet: InntektsmeldingEntitet, objectMapper: ObjectMapper): Inntektsmelding {
     var im = objectMapper.readValue(inntektsmeldingEntitet.data, Inntektsmelding::class.java)
-    if (im.journalStatus == JournalStatus.MIDLERTIDIG){
+    if (im.journalStatus == JournalStatus.MIDLERTIDIG) {
         im.journalStatus = JournalStatus.MOTTATT
     }
     return im


### PR DESCRIPTION
Tidligere var JournalpostStatus verdi som MIDLERTIDIG men ble med tiden døpt om til MOTTATT. 
Denne fiksen skal gjøre det mulig å lese ut MIDLERTIDIG og gjøre den om til MOTTATT.