### PR TITLE
Fjern ubrukte metrikker fra FritakAGP

### DIFF
--- a/src/main/kotlin/no/nav/syfo/Metrikker.kt
+++ b/src/main/kotlin/no/nav/syfo/Metrikker.kt
@@ -17,35 +17,3 @@ val FEILET_JOBB_COUNTER = Counter.build()
     .help("Counts the number of permanently failed jobs")
     .register()
 
-val BrukernotifikasjonerMetrics = Counter.build()
-    .namespace(METRICS_NS)
-    .name("brukernotifikasjoner")
-    .labelNames("skjematype")
-    .help("Antall brukernotifikasjoner sendt")
-    .register()
-
-object GravidKravMetrics :
-    ProseseringsMetrikker("gravid_krav", "Metrikker for krav, gravid")
-
-object KroniskKravMetrics :
-    ProseseringsMetrikker("kronisk_krav", "Metrikker for krav, kronisk")
-
-object GravidSoeknadMetrics :
-    ProseseringsMetrikker("gravid_soeknad", "Metrikker for søknader, gravid")
-
-object KroniskSoeknadMetrics :
-    ProseseringsMetrikker("kronisk_soeknad", "Metrikker for søknader, kronisk")
-
-abstract class ProseseringsMetrikker(metricName: String, metricHelpText: String) {
-    private val counter: Counter = Counter.build()
-        .namespace(METRICS_NS)
-        .name(metricName)
-        .labelNames("hendelse")
-        .help(metricHelpText)
-        .register()
-
-    fun tellMottatt() = counter.labels("mottatt").inc()
-    fun tellJournalfoert() = counter.labels("journalfoert").inc()
-    fun tellOppgaveOpprettet() = counter.labels("oppgaveOpprettet").inc()
-    fun tellKvitteringSendt() = counter.labels("kvitteringSendt").inc()
-}

--- a/src/main/kotlin/no/nav/syfo/Metrikker.kt
+++ b/src/main/kotlin/no/nav/syfo/Metrikker.kt
@@ -16,4 +16,3 @@ val FEILET_JOBB_COUNTER = Counter.build()
     .name("feilet_jobb")
     .help("Counts the number of permanently failed jobs")
     .register()
-


### PR DESCRIPTION
Det er blitt kopiert inn metrikker fra andre apper som ikke er i bruk