### PR TITLE
ÅrsakEndring er ikke årsakInnsending

### DIFF
--- a/src/main/kotlin/no/nav/syfo/simba/MapInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/syfo/simba/MapInntektsmelding.kt
@@ -48,6 +48,6 @@ fun mapInntektsmelding(arkivreferanse: String, aktorId: String, journalpostId: S
         Kontaktinformasjon("Ukjent", "n/a"),
         LocalDateTime.now(),
         BigDecimal(0),
-        imd.årsakInnsending.name
+        null
     )
 }

--- a/src/main/kotlin/no/nav/syfo/simba/MapInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/syfo/simba/MapInntektsmelding.kt
@@ -21,7 +21,7 @@ fun mapInntektsmelding(arkivreferanse: String, aktorId: String, journalpostId: S
         null,
         null,
         journalpostId,
-        imd.årsakInnsending.name,
+        imd.årsakInnsending.name.lowercase().replaceFirstChar { it.uppercase() },
         JournalStatus.FERDIGSTILT,
         imd.arbeidsgiverperioder.map { t -> Periode(t.fom, t.tom) },
         imd.beregnetInntekt,


### PR DESCRIPTION
Har stusset over dette en sund.
Virker som årsak til endring bare er satt til årsakInnsending.
Det er feil. gyldige verdier kan sees i tjenestespesifikasjonen her : https://github.com/navikt/tjenestespesifikasjoner/blob/master/nav-altinn-inntektsmelding/src/main/xsd/Inntektsmelding_kodelister_20190409.xsd
