### PR TITLE
Teamdokumenthandtering url oppdatering

### DIFF
--- a/deploy/dev.yaml
+++ b/deploy/dev.yaml
@@ -81,7 +81,7 @@ spec:
     - name: OPPGAVEBEHANDLING_URL
       value: "https://oppgave.nais.preprod.local/api/v1/oppgaver"
     - name: OPPRETT_SAK_URL
-      value: "https://sak.nais.preprod.local/api/v1/saker"
+      value: "https://sak-q1.dev.intern.nav.no/api/v1/saker"
     - name: SRVAPPSERVER_USERNAME
       value: "srvappserver"
     - name: SRVAPPSERVER_PASSWORD
@@ -95,7 +95,7 @@ spec:
     - name: KAFKA_UTSATT_OPPGAVE_TOPIC
       value: "tbd.spre-oppgaver"
     - name: DOKARKIV_URL
-      value: "https://dokarkiv-q1.nais.preprod.local/rest/journalpostapi/v1"
+      value: "https://dokarkiv-q1.dev.intern.nav.no/rest/journalpostapi/v1"
     - name: DATAPAKKE_ID
       value: "fb74c8d14d9c579e05b0b4b587843e6b"
     - name: DATAPAKKE_API_URL
@@ -107,8 +107,8 @@ spec:
     - name: NORG2_URL
       value: "https://norg2.dev.adeo.no/norg2/api/v1"
     - name: SAF_DOKUMENT_URL
-      value: "https://saf-q1.nais.preprod.local/rest"
+      value: "https://saf-q1.dev.intern.nav.no/rest"
     - name: SAF_JOURNAL_URL
-      value: "https://saf-q1.nais.preprod.local/graphql"
+      value: "https://saf-q1.dev.intern.nav.no/graphql"
     - name: ENHETSREGISTERET_URL
       value: "https://data.brreg.no/enhetsregisteret/api/underenheter/"

--- a/deploy/prod.yaml
+++ b/deploy/prod.yaml
@@ -77,7 +77,7 @@ spec:
     - name: OPPGAVEBEHANDLING_URL
       value: "http://oppgave.default.svc.nais.local/api/v1/oppgaver"
     - name: OPPRETT_SAK_URL
-      value: "http://sak.default.svc.nais.local/api/v1/saker"
+      value: "http://sak.teamdokumenthandtering.svc.nais.local/api/v1/saker"
     - name: SRVAPPSERVER_USERNAME
       value: "srvappserver"
     - name: SRVAPPSERVER_PASSWORD
@@ -91,7 +91,7 @@ spec:
     - name: KAFKA_UTSATT_OPPGAVE_TOPIC
       value: "tbd.spre-oppgaver"
     - name: DOKARKIV_URL
-      value: "https://dokarkiv.nais.adeo.no/rest/journalpostapi/v1"
+      value: "https://dokarkiv.intern.nav.no/rest/journalpostapi/v1"
     - name: DATAPAKKE_ID
       value: "fb74c8d14d9c579e05b0b4b587843e6b"
     - name: DATAPAKKE_API_URL
@@ -103,8 +103,8 @@ spec:
     - name: NORG2_URL
       value: "https://norg2.nais.adeo.no/norg2/api/v1"
     - name: SAF_DOKUMENT_URL
-      value: "https://saf.nais.adeo.no/rest"
+      value: "https://saf.intern.nav.no/rest"
     - name: SAF_JOURNAL_URL
-      value: "https://saf.nais.adeo.no/graphql"
+      value: "https://saf.intern.nav.no/graphql"
     - name: ENHETSREGISTERET_URL
       value: "https://data.brreg.no/enhetsregisteret/api/underenheter/"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -119,7 +119,7 @@ aad_syfoinntektsmelding_clientid_password: ${?AAD_SYFOINNTEKTSMELDING_CLIENTID_P
 
 inntektsmelding_lagringstid_maneder: "3"
 
-opprett_sak_url:"http://sak.default.svc.nais.local/api/v1/saker"
+opprett_sak_url:"http://sak.teamdokumenthandtering.svc.nais.local/api/v1/saker"
 opprett_sak_url: ${?OPPRETT_SAK_URL}
 
 kafka_bootstrap_servers: "localhost:9092"


### PR DESCRIPTION
I NAIS sitt Kubernetes miljø ble det innført overgang fra standard namespace "default" til team namespace "team". Denne endringen påvirket også URL-ene for Kubernetes-tjenesteoppdagelse. Det ble slutt på oppretting av ressurser i default namespace den 29. september 2021.

Tidligere var en vanlig NAIS tjenesteoppdagelses-URL i Kubernetes som følger: "http://app.default/". Her refererte "default" til standardnavneområdet der tjenesten var plassert. Men nå, med innføringen av teamnavneområder, har URL-en blitt endret til "http://app.team/". Dette betyr at "team" erstatter "default" i URL-en og representerer det tilhørende teamet eller prosjektet som tjenesten tilhører.

For å lette denne overgangen ble det manuelt opprettet service redirects i default namespacet.

Vi ser at appen deres har en referanse til en av teamdokumenthandtering sine redirect service adresser. Denne patchen tar ned risiko for at dette skal feile i produksjon ved misforståelser, opprydding eller annet i default namespace til NAIS clusteret.