### PR TITLE
Ignorer JournalpostHendelser som ikke er JournalpostMottat

### DIFF
--- a/src/main/kotlin/no/nav/syfo/integration/kafka/journalpost/JournalpostHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/integration/kafka/journalpost/JournalpostHendelseConsumer.kt
@@ -23,7 +23,7 @@ class JournalpostHendelseConsumer(
     topicName: String,
     private val duplikatRepository: DuplikatRepository,
     private val bakgrunnsjobbRepo: BakgrunnsjobbRepository,
-    private val om: ObjectMapper,
+    private val om: ObjectMapper
 ) : ReadynessComponent, LivenessComponent {
 
     private val log = LoggerFactory.getLogger(JournalpostHendelseConsumer::class.java)

--- a/src/test/kotlin/no/nav/syfo/integration/kafka/journalpost/JournalpostHendelseConsumerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/integration/kafka/journalpost/JournalpostHendelseConsumerTest.kt
@@ -27,7 +27,7 @@ class JournalpostHendelseConsumerTest {
     val GYLDIG_INNTEKTSMELDING = InngaaendeJournalpostDTO("abc", 1, "JournalpostMottatt", 111, "MOTTATT", "", "SYK", "ALTINN", "", "")
     val DUPLIKAT_INNTEKTSMELDING = GYLDIG_INNTEKTSMELDING.copy(journalpostId = 222)
     val IKKE_INNTEKTSMELDING = InngaaendeJournalpostDTO("abc", 1, "JournalpostMottatt", 333, "IKKE_MOTTATT", "", "IKKE_SYK", "IKKE_ALTINN", "", "")
-    val FEIL_HENDELSE_TYPE = InngaaendeJournalpostDTO("abc", 1, "TemaEndret", 333, "IKKE_MOTTATT", "", "IKKE_SYK", "IKKE_ALTINN", "", "")
+    val FEIL_HENDELSE_TYPE = InngaaendeJournalpostDTO("abc", 1, "TemaEndret", 333, "MOTTATT", "", "SYK", "ALTINN", "", "")
 
     @BeforeEach
     fun before() {

--- a/src/test/kotlin/no/nav/syfo/integration/kafka/journalpost/JournalpostHendelseConsumerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/integration/kafka/journalpost/JournalpostHendelseConsumerTest.kt
@@ -26,7 +26,8 @@ class JournalpostHendelseConsumerTest {
     lateinit var consumer: JournalpostHendelseConsumer
     val GYLDIG_INNTEKTSMELDING = InngaaendeJournalpostDTO("abc", 1, "JournalpostMottatt", 111, "MOTTATT", "", "SYK", "ALTINN", "", "")
     val DUPLIKAT_INNTEKTSMELDING = GYLDIG_INNTEKTSMELDING.copy(journalpostId = 222)
-    val IKKE_INNTEKTSMELDING = InngaaendeJournalpostDTO("abc", 1, "", 333, "IKKE_MOTTATT", "", "IKKE_SYK", "IKKE_ALTINN", "", "")
+    val IKKE_INNTEKTSMELDING = InngaaendeJournalpostDTO("abc", 1, "JournalpostMottatt", 333, "IKKE_MOTTATT", "", "IKKE_SYK", "IKKE_ALTINN", "", "")
+    val FEIL_HENDELSE_TYPE = InngaaendeJournalpostDTO("abc", 1, "TemaEndret", 333, "IKKE_MOTTATT", "", "IKKE_SYK", "IKKE_ALTINN", "", "")
 
     @BeforeEach
     fun before() {
@@ -105,6 +106,15 @@ class JournalpostHendelseConsumerTest {
             duplikatRepository.findByHendelsesId(any())
         } returns false
         assertEquals(JournalpostStatus.IkkeInntektsmelding, consumer.findStatus(IKKE_INNTEKTSMELDING))
+        verify(exactly = 0) { bakgrunnsjobbRepo.save(any()) }
+    }
+
+    @Test
+    fun skal_gjenkjenne_feil_hendelser() {
+        every {
+            duplikatRepository.findByHendelsesId(any())
+        } returns false
+        assertEquals(JournalpostStatus.FeilHendelseType, consumer.findStatus(FEIL_HENDELSE_TYPE))
         verify(exactly = 0) { bakgrunnsjobbRepo.save(any()) }
     }
 

--- a/src/test/kotlin/no/nav/syfo/integration/kafka/journalpost/JournalpostHendelseConsumerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/integration/kafka/journalpost/JournalpostHendelseConsumerTest.kt
@@ -24,7 +24,7 @@ class JournalpostHendelseConsumerTest {
     var props = joarkLocalProperties().toMap()
     val topicName = "topic"
     lateinit var consumer: JournalpostHendelseConsumer
-    val GYLDIG_INNTEKTSMELDING = InngaaendeJournalpostDTO("abc", 1, "", 111, "MOTTATT", "", "SYK", "ALTINN", "", "")
+    val GYLDIG_INNTEKTSMELDING = InngaaendeJournalpostDTO("abc", 1, "JournalpostMottatt", 111, "MOTTATT", "", "SYK", "ALTINN", "", "")
     val DUPLIKAT_INNTEKTSMELDING = GYLDIG_INNTEKTSMELDING.copy(journalpostId = 222)
     val IKKE_INNTEKTSMELDING = InngaaendeJournalpostDTO("abc", 1, "", 333, "IKKE_MOTTATT", "", "IKKE_SYK", "IKKE_ALTINN", "", "")
 


### PR DESCRIPTION
Ifølge Morten L([trello](https://trello.com/c/IrYnMynV)) så var det noen hendelser vi ikke skal lytte på, og det kunne skape problemer i prod.
Altså:  Status = Mottatt men hendelse !=JournalpostMottatt i noen tilfeller.
I praksis er det ikke sikkert dette skjer så ofte, men la til logging så vi kan tracke det.

Dokumentasjon:
https://confluence.adeo.no/display/BOA/Joarkhendelser