### PR TITLE
Fix for meldingstap i SIMBA-consumer 

### DIFF
--- a/deploy/dev.yml
+++ b/deploy/dev.yml
@@ -6,6 +6,8 @@ metadata:
   labels:
     team: helsearbeidsgiver
 spec:
+  strategy:
+    type: Recreate
   ingresses:
     - https://spinosaurus.intern.dev.nav.no
   image: {{image}}

--- a/deploy/prod.yml
+++ b/deploy/prod.yml
@@ -7,7 +7,7 @@ metadata:
     team: helsearbeidsgiver
 spec:
   strategy:
-    type: RollingUpdate
+    type: Recreate
   image: {{image}}
   port: 8080
   prometheus:

--- a/deploy/prod.yml
+++ b/deploy/prod.yml
@@ -6,6 +6,8 @@ metadata:
   labels:
     team: helsearbeidsgiver
 spec:
+  strategy:
+    type: RollingUpdate
   image: {{image}}
   port: 8080
   prometheus:

--- a/deploy/prod.yml
+++ b/deploy/prod.yml
@@ -14,10 +14,10 @@ spec:
     enabled: true
     path: /metrics
   liveness:
-    failureThreshold: 600
+    failureThreshold: 6
     initialDelay: 60
     path: /health/is-alive
-    periodSeconds: 6
+    periodSeconds: 10
     timeout: 3
   readiness:
     initialDelay: 60

--- a/src/main/kotlin/no/nav/syfo/behandling/InntektsmeldingBehandler.kt
+++ b/src/main/kotlin/no/nav/syfo/behandling/InntektsmeldingBehandler.kt
@@ -41,7 +41,7 @@ class InntektsmeldingBehandler(
         return behandleInntektsmelding(arkivreferanse, inntektsmelding)
     }
 
-    fun behandleInntektsmelding(arkivreferanse: String, inntektsmelding: Inntektsmelding): String? {
+    private fun behandleInntektsmelding(arkivreferanse: String, inntektsmelding: Inntektsmelding): String? {
         var ret: String? = null
         val consumerLock = consumerLocks.get(inntektsmelding.fnr)
         try {

--- a/src/main/kotlin/no/nav/syfo/integration/kafka/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/integration/kafka/KafkaConfig.kt
@@ -31,7 +31,7 @@ fun joarkLocalProperties() = consumerLocalProperties() + mapOf(
 
 fun inntektsmeldingFraSimbaLocalProperties() = consumerLocalProperties() + mapOf(
     "schema.registry.url" to "http://kafka-schema-registry.tpa.svc.nais.local:8081",
-    ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to GenericAvroDeserializer::class.java,
+    ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java,
     ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest",
     ConsumerConfig.CLIENT_ID_CONFIG to "syfoinntektsmelding",
     ConsumerConfig.GROUP_ID_CONFIG to "syfoinntektsmelding-v1"

--- a/src/main/kotlin/no/nav/syfo/koin/DevKoinProfile.kt
+++ b/src/main/kotlin/no/nav/syfo/koin/DevKoinProfile.kt
@@ -176,6 +176,8 @@ fun devConfig(config: ApplicationConfig) = module {
         InntektsmeldingConsumer(
             commonAivenProperties() + mapOf(
                 ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest",
+                ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to "false",
+                ConsumerConfig.MAX_POLL_RECORDS_CONFIG to "1",
                 ConsumerConfig.CLIENT_ID_CONFIG to "syfoinntektsmelding-im-consumer",
                 ConsumerConfig.GROUP_ID_CONFIG to "syfoinntektsmelding-im-v1",
                 ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java,

--- a/src/main/kotlin/no/nav/syfo/koin/DevKoinProfile.kt
+++ b/src/main/kotlin/no/nav/syfo/koin/DevKoinProfile.kt
@@ -185,8 +185,7 @@ fun devConfig(config: ApplicationConfig) = module {
             get(),
             get(),
             get(),
-            get(),
-            skalKrasjeVedPDLFeil = false
+            get()
         )
     }
 }

--- a/src/main/kotlin/no/nav/syfo/koin/DevKoinProfile.kt
+++ b/src/main/kotlin/no/nav/syfo/koin/DevKoinProfile.kt
@@ -185,7 +185,8 @@ fun devConfig(config: ApplicationConfig) = module {
             get(),
             get(),
             get(),
-            get()
+            get(),
+            skalKastePdlFeil = false
         )
     }
 }

--- a/src/main/kotlin/no/nav/syfo/koin/DevKoinProfile.kt
+++ b/src/main/kotlin/no/nav/syfo/koin/DevKoinProfile.kt
@@ -186,7 +186,7 @@ fun devConfig(config: ApplicationConfig) = module {
             get(),
             get(),
             get(),
-            skalKastePdlFeil = false
+            skalKrasjeVedPDLFeil = false
         )
     }
 }

--- a/src/main/kotlin/no/nav/syfo/koin/ProdKoinProfile.kt
+++ b/src/main/kotlin/no/nav/syfo/koin/ProdKoinProfile.kt
@@ -175,6 +175,8 @@ fun prodConfig(config: ApplicationConfig) = module {
     single {
         InntektsmeldingConsumer(
             commonAivenProperties() + mapOf(
+                ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to "false", // viktig!
+                ConsumerConfig.MAX_POLL_RECORDS_CONFIG to "1", // også viktig - unngår at vi commiter for stort offset hvis vi henter flere og feiler midt i batchen
                 ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest",
                 ConsumerConfig.CLIENT_ID_CONFIG to "syfoinntektsmelding-im-consumer",
                 ConsumerConfig.GROUP_ID_CONFIG to "syfoinntektsmelding-im-v1",

--- a/src/main/kotlin/no/nav/syfo/simba/InntektsmeldingConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/simba/InntektsmeldingConsumer.kt
@@ -30,7 +30,7 @@ class InntektsmeldingConsumer(
     private val inntektsmeldingAivenProducer: InntektsmeldingAivenProducer,
     private val utsattOppgaveService: UtsattOppgaveService,
     private val pdlClient: PdlClient,
-    private val skalKastePdlFeil: Boolean = true
+    private val skalKasteExceptionVedPDLFeil: Boolean = true
 ) : ReadynessComponent, LivenessComponent {
 
     private val consumer = KafkaConsumer<String, String>(props)
@@ -128,7 +128,7 @@ class InntektsmeldingConsumer(
         val aktorid = pdlClient.getAktørid(identitetsnummer)
         if (aktorid == null) {
             sikkerlogger.error("Fant ikke aktøren for: $identitetsnummer")
-            if (skalKastePdlFeil) { // Oppslag feiler i dev-miljøer om ikke brukere er opprettet i PDL - og dev wipes rett som det er
+            if (skalKasteExceptionVedPDLFeil) { // Oppslag feiler i dev-miljøer om ikke brukere er opprettet i PDL - og dev wipes rett som det er
                 throw FantIkkeAktørException(null)
             }
         }

--- a/src/main/kotlin/no/nav/syfo/simba/InntektsmeldingConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/simba/InntektsmeldingConsumer.kt
@@ -90,7 +90,7 @@ class InntektsmeldingConsumer(
     }
 
     private fun behandle(journalpostId: String, inntektsmeldingFraSimba: Inntektsmelding) {
-        val aktorid = hentAktøridFraPDL(inntektsmeldingFraSimba.identitetsnummer)
+        val aktorid = hentAktoeridFraPDL(inntektsmeldingFraSimba.identitetsnummer)
         val arkivreferanse = "im_$journalpostId"
         val inntektsmelding = mapInntektsmelding(arkivreferanse, aktorid, journalpostId, inntektsmeldingFraSimba)
         val dto = inntektsmeldingService.lagreBehandling(inntektsmelding, aktorid)
@@ -124,7 +124,7 @@ class InntektsmeldingConsumer(
         sikkerlogger.info("Publiserte inntektsmelding på topic: $inntektsmelding")
     }
 
-    private fun hentAktøridFraPDL(identitetsnummer: String): String {
+    private fun hentAktoeridFraPDL(identitetsnummer: String): String {
         val aktorid = pdlClient.getAktørid(identitetsnummer)
         if (aktorid == null) {
             sikkerlogger.error("Fant ikke aktøren for: $identitetsnummer")

--- a/src/main/kotlin/no/nav/syfo/simba/InntektsmeldingConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/simba/InntektsmeldingConsumer.kt
@@ -30,7 +30,7 @@ class InntektsmeldingConsumer(
     private val inntektsmeldingAivenProducer: InntektsmeldingAivenProducer,
     private val utsattOppgaveService: UtsattOppgaveService,
     private val pdlClient: PdlClient,
-    private val skalKrasjeVedPDLFeil: Boolean = true
+    private val skalKastePdlFeil: Boolean = true
 ) : ReadynessComponent, LivenessComponent {
 
     private val consumer = KafkaConsumer<String, String>(props)
@@ -128,7 +128,7 @@ class InntektsmeldingConsumer(
         val aktorid = pdlClient.getAktørid(identitetsnummer)
         if (aktorid == null) {
             sikkerlogger.error("Fant ikke aktøren for: $identitetsnummer")
-            if (skalKrasjeVedPDLFeil) { // Oppslag feiler i dev-miljøer om ikke brukere er opprettet i PDL - og dev wipes rett som det er
+            if (skalKastePdlFeil) { // Oppslag feiler i dev-miljøer om ikke brukere er opprettet i PDL - og dev wipes rett som det er
                 throw FantIkkeAktørException(null)
             }
         }

--- a/src/main/kotlin/no/nav/syfo/simba/InntektsmeldingConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/simba/InntektsmeldingConsumer.kt
@@ -58,7 +58,7 @@ class InntektsmeldingConsumer(
             setIsReady(true)
             while (!error) {
                 it
-                    .poll(Duration.ofMillis(1000))
+                    .poll(Duration.ofMillis(100))
                     .forEach { record ->
                         try {
                             behandleRecord(record)

--- a/src/main/kotlin/no/nav/syfo/simba/InntektsmeldingConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/simba/InntektsmeldingConsumer.kt
@@ -18,6 +18,7 @@ import no.nav.syfo.service.InntektsmeldingService
 import no.nav.syfo.util.getAktørid
 import no.nav.syfo.util.validerInntektsmelding
 import no.nav.syfo.utsattoppgave.UtsattOppgaveService
+import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import java.time.Duration
 import java.time.LocalDateTime
@@ -28,7 +29,8 @@ class InntektsmeldingConsumer(
     private val inntektsmeldingService: InntektsmeldingService,
     private val inntektsmeldingAivenProducer: InntektsmeldingAivenProducer,
     private val utsattOppgaveService: UtsattOppgaveService,
-    private val pdlClient: PdlClient
+    private val pdlClient: PdlClient,
+    private val skalKastePdlFeil: Boolean = true
 ) : ReadynessComponent, LivenessComponent {
 
     private val consumer = KafkaConsumer<String, String>(props)
@@ -59,17 +61,7 @@ class InntektsmeldingConsumer(
                     .poll(Duration.ofMillis(1000))
                     .forEach { record ->
                         try {
-                            val value = record.value()
-                            sikkerlogger.info("InntektsmeldingConsumer: Mottar record fra Simba: $value")
-                            val meldingFraSimba = value.fromJson(JournalfoertInntektsmelding.serializer())
-
-                            val im = inntektsmeldingService.findByJournalpost(meldingFraSimba.journalpostId)
-                            if (im != null) {
-                                sikkerlogger.info("InntektsmeldingConsumer: Behandler ikke ${meldingFraSimba.journalpostId}. Finnes allerede.")
-                            } else {
-                                behandle(meldingFraSimba.journalpostId, meldingFraSimba.inntektsmelding)
-                                log.info("InntektsmeldingConsumer: Behandlet inntektsmelding med journalpostid: ${meldingFraSimba.journalpostId}")
-                            }
+                            behandleRecord(record)
                             it.commitSync()
                         } catch (e: Throwable) {
                             sikkerlogger.error("InntektsmeldingConsumer: Klarte ikke behandle: ${record.value()}", e)
@@ -81,13 +73,25 @@ class InntektsmeldingConsumer(
         }
     }
 
-    private fun behandle(journalpostId: String, inntektsmeldingFraSimba: Inntektsmelding) {
-        val aktorid = pdlClient.getAktørid(inntektsmeldingFraSimba.identitetsnummer)
-        val arkivreferanse = "im_$journalpostId"
-        if (aktorid == null) {
-            sikkerlogger.error("Fant ikke aktøren for arkivreferansen: $arkivreferanse")
-            throw FantIkkeAktørException(null)
+    private fun behandleRecord(
+        record: ConsumerRecord<String, String>,
+    ) {
+        val value = record.value()
+        sikkerlogger.info("InntektsmeldingConsumer: Mottar record fra Simba: $value")
+        val meldingFraSimba = value.fromJson(JournalfoertInntektsmelding.serializer())
+
+        val im = inntektsmeldingService.findByJournalpost(meldingFraSimba.journalpostId)
+        if (im != null) {
+            sikkerlogger.info("InntektsmeldingConsumer: Behandler ikke ${meldingFraSimba.journalpostId}. Finnes allerede.")
+        } else {
+            behandle(meldingFraSimba.journalpostId, meldingFraSimba.inntektsmelding)
+            log.info("InntektsmeldingConsumer: Behandlet inntektsmelding med journalpostid: ${meldingFraSimba.journalpostId}")
         }
+    }
+
+    private fun behandle(journalpostId: String, inntektsmeldingFraSimba: Inntektsmelding) {
+        val aktorid = hentAktøridFraPDL(inntektsmeldingFraSimba.identitetsnummer)
+        val arkivreferanse = "im_$journalpostId"
         val inntektsmelding = mapInntektsmelding(arkivreferanse, aktorid, journalpostId, inntektsmeldingFraSimba)
         val dto = inntektsmeldingService.lagreBehandling(inntektsmelding, aktorid)
 
@@ -118,6 +122,17 @@ class InntektsmeldingConsumer(
         inntektsmeldingAivenProducer.leggMottattInntektsmeldingPåTopics(mappedInntektsmelding)
 
         sikkerlogger.info("Publiserte inntektsmelding på topic: $inntektsmelding")
+    }
+
+    private fun hentAktøridFraPDL(identitetsnummer: String): String {
+        val aktorid = pdlClient.getAktørid(identitetsnummer)
+        if (aktorid == null) {
+            sikkerlogger.error("Fant ikke aktøren for: $identitetsnummer")
+            if (skalKastePdlFeil) { // Oppslag feiler i dev-miljøer om ikke brukere er opprettet i PDL - og dev wipes rett som det er
+                throw FantIkkeAktørException(null)
+            }
+        }
+        return aktorid ?: "AktørID"
     }
 
     override suspend fun runReadynessCheck() {

--- a/src/main/kotlin/no/nav/syfo/simba/InntektsmeldingConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/simba/InntektsmeldingConsumer.kt
@@ -30,7 +30,7 @@ class InntektsmeldingConsumer(
     private val inntektsmeldingAivenProducer: InntektsmeldingAivenProducer,
     private val utsattOppgaveService: UtsattOppgaveService,
     private val pdlClient: PdlClient,
-    private val skalKastePdlFeil: Boolean = true
+    private val skalKrasjeVedPDLFeil: Boolean = true
 ) : ReadynessComponent, LivenessComponent {
 
     private val consumer = KafkaConsumer<String, String>(props)
@@ -128,7 +128,7 @@ class InntektsmeldingConsumer(
         val aktorid = pdlClient.getAktørid(identitetsnummer)
         if (aktorid == null) {
             sikkerlogger.error("Fant ikke aktøren for: $identitetsnummer")
-            if (skalKastePdlFeil) { // Oppslag feiler i dev-miljøer om ikke brukere er opprettet i PDL - og dev wipes rett som det er
+            if (skalKrasjeVedPDLFeil) { // Oppslag feiler i dev-miljøer om ikke brukere er opprettet i PDL - og dev wipes rett som det er
                 throw FantIkkeAktørException(null)
             }
         }

--- a/src/main/kotlin/no/nav/syfo/util/PdlUtils.kt
+++ b/src/main/kotlin/no/nav/syfo/util/PdlUtils.kt
@@ -2,5 +2,20 @@ package no.nav.syfo.util
 
 import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlClient
 import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlIdent
+import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 
-fun PdlClient.getAktørid(fnr: String): String? = this.fullPerson(fnr)?.hentIdenter?.trekkUtIdent(PdlIdent.PdlIdentGruppe.AKTORID)
+fun PdlClient.getAktørid(fnr: String): String? {
+    // TODO: ktor 2 har retry-mulighet i httpClient, oppgrader og erstatt denne quick-fixen...
+    val retryMs = 500L
+    return try {
+        this.fullPerson(fnr)?.hentIdenter?.trekkUtIdent(PdlIdent.PdlIdentGruppe.AKTORID)
+    } catch (e: Exception) {
+        sikkerLogger().warn("Kall til PDL feilet, venter $retryMs ms og forsøker igjen..")
+        Thread.sleep(retryMs)
+        try {
+            this.fullPerson(fnr)?.hentIdenter?.trekkUtIdent(PdlIdent.PdlIdentGruppe.AKTORID)
+        } catch (e2: Exception) {
+            null
+        }
+    }
+}


### PR DESCRIPTION
+ Enkel retry ved pdl-feil
+ Recreate-strategy ved deploy (unngå at to instanser spiser bakgrunnsjobber)
+ Ekstra tid til å avslutte ved shutdown
+ Raskere restart (ett minutt) når feil oppstår
