### PR TITLE
Øk timeout med 24 timer dvs til 72 timer for gosys oppgaver

### DIFF
--- a/src/main/kotlin/no/nav/syfo/utsattoppgave/UtsattOppgaveDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/utsattoppgave/UtsattOppgaveDAO.kt
@@ -21,6 +21,6 @@ class UtsattOppgaveDAO(private val utsattOppgaveRepository: UtsattOppgaveReposit
     }
 
     fun finnAlleUtgåtteOppgaver(): List<UtsattOppgaveEntitet> =
-        utsattOppgaveRepository.findUtsattOppgaveEntitetByTimeoutBeforeAndTilstandEquals(LocalDateTime.now(), Tilstand.Utsatt)
+        utsattOppgaveRepository.findUtsattOppgaveEntitetByTimeoutBeforeAndTilstandEquals(LocalDateTime.now().minusHours(24), Tilstand.Utsatt)
             .also { logger.info("Fant ${it.size} utsatte oppgaver som har timet ut hvor vi skal opprette en oppgave i gosys") }
 }

--- a/src/test/kotlin/no/nav/syfo/repository/UtsattOppgaveRepositoryImpSpec.kt
+++ b/src/test/kotlin/no/nav/syfo/repository/UtsattOppgaveRepositoryImpSpec.kt
@@ -53,6 +53,31 @@ open class UtsattOppgaveRepositoryImpSpec : SystemTestBase() {
     }
 
     @Test
+    fun `finner ikke utsatt oppgave hvis timout er 24 timer senere`() {
+        repository.opprett(
+            UtsattOppgaveEntitet(
+                id = 0,
+                inntektsmeldingId = "id",
+                arkivreferanse = "arkivref",
+                fnr = "fnr",
+                aktørId = "aktørId",
+                journalpostId = "journalpostId",
+                timeout = now().minusHours(1),
+                tilstand = Tilstand.Utsatt,
+                gosysOppgaveId = null,
+                oppdatert = null,
+                speil = false,
+                utbetalingBruker = false
+            )
+        )
+
+        val oppgaver =
+            repository.findUtsattOppgaveEntitetByTimeoutBeforeAndTilstandEquals(now().minusHours(24), Tilstand.Utsatt)
+
+        Assertions.assertEquals(0, oppgaver.size)
+    }
+
+    @Test
     fun `Databasen angir ID ved opprettelse`() {
         val firstId = repository.opprett(
             UtsattOppgaveEntitet(


### PR DESCRIPTION
Siden infotrygd replikeringen er nede så trenger vi øke timeout for å sikre at vi ikke oppretter for mange oppgaver.
se [tråd](https://nav-it.slack.com/archives/C019637N90X/p1730203167920369) for mer info