### PR TITLE
Bruk inntektsmelding-ID fra Simba

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dto/InntektsmeldingEntitet.kt
+++ b/src/main/kotlin/no/nav/syfo/dto/InntektsmeldingEntitet.kt
@@ -2,10 +2,9 @@ package no.nav.syfo.dto
 
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.UUID
 
 data class InntektsmeldingEntitet(
-    val uuid: String = UUID.randomUUID().toString(),
+    val uuid: String,
     var aktorId: String,
     var journalpostId: String,
     var orgnummer: String? = null,

--- a/src/main/kotlin/no/nav/syfo/mapping/InntektsmeldingDtoMapper.kt
+++ b/src/main/kotlin/no/nav/syfo/mapping/InntektsmeldingDtoMapper.kt
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import no.nav.syfo.domain.JournalStatus
 import no.nav.syfo.domain.inntektsmelding.Inntektsmelding
 import no.nav.syfo.dto.InntektsmeldingEntitet
+import java.util.UUID
 
 fun toInntektsmeldingEntitet(inntektsmelding: Inntektsmelding): InntektsmeldingEntitet {
     val entitet = InntektsmeldingEntitet(
+        uuid = inntektsmelding.id.ifEmpty { UUID.randomUUID().toString() },
         aktorId = inntektsmelding.aktorId ?: "",
         journalpostId = inntektsmelding.journalpostId,
         arbeidsgiverPrivat = inntektsmelding.arbeidsgiverPrivatFnr,

--- a/src/main/kotlin/no/nav/syfo/simba/MapInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/syfo/simba/MapInntektsmelding.kt
@@ -56,6 +56,7 @@ fun mapInntektsmelding(
         journalStatus = JournalStatus.FERDIGSTILT,
         sakId = "",
         arkivRefereranse = arkivreferanse,
+        id = im.id.toString(),
         aktorId = aktorId,
         journalpostId = journalpostId,
         avsenderSystem = AvsenderSystem(avsenderSystem, Avsender.VERSJON),

--- a/src/test/kotlin/no/nav/syfo/UtsattOppgaveTestData.kt
+++ b/src/test/kotlin/no/nav/syfo/UtsattOppgaveTestData.kt
@@ -30,6 +30,7 @@ object UtsattOppgaveTestData {
     )
 
     val inntektsmeldingEntitet = InntektsmeldingEntitet(
+        uuid = UUID.randomUUID().toString(),
         aktorId = "aktoerid-123",
         behandlet = LocalDateTime.now(),
         orgnummer = "arb-org-123",

--- a/src/test/kotlin/no/nav/syfo/behandling/InntektsmeldingBehandlerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/behandling/InntektsmeldingBehandlerTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.util.UUID
 
 class InntektsmeldingBehandlerTest {
 
@@ -40,6 +41,7 @@ class InntektsmeldingBehandlerTest {
         every { pdlClient.getAktørid("fnr") } returns "aktorId" // inntektsmelding.fnr
         every { inntektsmeldingService.lagreBehandling(any(), any()) } returns
             InntektsmeldingEntitet(
+                uuid = UUID.randomUUID().toString(),
                 orgnummer = "orgnummer",
                 arbeidsgiverPrivat = "123",
                 aktorId = "aktorId",

--- a/src/test/kotlin/no/nav/syfo/repository/InntektsmeldingRepositorySpec.kt
+++ b/src/test/kotlin/no/nav/syfo/repository/InntektsmeldingRepositorySpec.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.util.UUID
 
 open class InntektsmeldingRepositorySpec : SystemTestBase() {
 
@@ -41,6 +42,7 @@ open class InntektsmeldingRepositorySpec : SystemTestBase() {
     @Test
     fun findByJournalpostId() {
         val inntektsmelding = InntektsmeldingEntitet(
+            uuid = UUID.randomUUID().toString(),
             journalpostId = "jp-123-987",
             behandlet = LocalDateTime.of(2019, 10, 1, 5, 18, 45, 0),
             orgnummer = "orgnummer",
@@ -55,6 +57,7 @@ open class InntektsmeldingRepositorySpec : SystemTestBase() {
     fun findByAktorId() {
         val behandlet = LocalDateTime.of(2019, 10, 1, 5, 18, 45, 0)
         val inntektsmelding = InntektsmeldingEntitet(
+            uuid = UUID.randomUUID().toString(),
             journalpostId = "journalpostId",
             behandlet = behandlet,
             orgnummer = "orgnummer",
@@ -83,6 +86,7 @@ open class InntektsmeldingRepositorySpec : SystemTestBase() {
     fun lagre_flere_arbeidsgiverperioder() {
         val behandlet = LocalDateTime.of(2019, 10, 1, 5, 18, 45, 0)
         val inntektsmelding = InntektsmeldingEntitet(
+            uuid = UUID.randomUUID().toString(),
             journalpostId = "journalpostId",
             behandlet = behandlet,
             orgnummer = "orgnummer",
@@ -106,6 +110,7 @@ open class InntektsmeldingRepositorySpec : SystemTestBase() {
     fun lagre_uten_arbeidsgiverperioder() {
         val behandlet = LocalDateTime.of(2019, 10, 1, 5, 18, 45, 0)
         val inntektsmelding = InntektsmeldingEntitet(
+            uuid = UUID.randomUUID().toString(),
             journalpostId = "journalpostId",
             behandlet = behandlet,
             orgnummer = "orgnummer",
@@ -164,6 +169,7 @@ open class InntektsmeldingRepositorySpec : SystemTestBase() {
         )
         val mapper = JacksonJsonConfig.objectMapperFactory.opprettObjectMapper()
         val inntektsmelding = InntektsmeldingEntitet(
+            uuid = UUID.randomUUID().toString(),
             journalpostId = "journalpostId",
             behandlet = LocalDateTime.now(),
             orgnummer = "orgnummer",
@@ -225,6 +231,7 @@ open class InntektsmeldingRepositorySpec : SystemTestBase() {
 
     private fun lagInntektsmelding(behandlet: LocalDateTime): InntektsmeldingEntitet {
         return InntektsmeldingEntitet(
+            uuid = UUID.randomUUID().toString(),
             journalpostId = "journalpostId",
             behandlet = behandlet,
             orgnummer = "orgnummer",

--- a/src/test/kotlin/no/nav/syfo/service/InntektsmeldingServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/service/InntektsmeldingServiceTest.kt
@@ -20,6 +20,7 @@ import org.junit.Assert.assertTrue
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.LocalDateTime
+import java.util.UUID
 
 class InntektsmeldingServiceTest {
 
@@ -165,6 +166,7 @@ class InntektsmeldingServiceTest {
 
     fun buildEntitet(aktorId: String, im: Inntektsmelding): InntektsmeldingEntitet {
         return InntektsmeldingEntitet(
+            uuid = UUID.randomUUID().toString(),
             aktorId = aktorId,
             behandlet = LocalDateTime.now(),
             orgnummer = "arb-org-123",


### PR DESCRIPTION
Når Spleis og HAG bruker samme ID for inntektsmelding blir det lettere å finne en spesifikk dersom vi vil undersøke noe.