### PR TITLE
Bruk normal timeout på utsatt oppgave

### DIFF
--- a/src/main/kotlin/no/nav/syfo/utsattoppgave/UtsattOppgaveDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/utsattoppgave/UtsattOppgaveDAO.kt
@@ -20,9 +20,7 @@ class UtsattOppgaveDAO(private val utsattOppgaveRepository: UtsattOppgaveReposit
     }
 
     fun finnAlleUtgåtteOppgaver(): List<UtsattOppgaveEntitet> =
-        utsattOppgaveRepository.findUtsattOppgaveEntitetByTimeoutBeforeAndTilstandEquals(
-            LocalDateTime.now().minusHours(168),
-            Tilstand.Utsatt,
-        )
+        utsattOppgaveRepository
+            .findUtsattOppgaveEntitetByTimeoutBeforeAndTilstandEquals(LocalDateTime.now(), Tilstand.Utsatt)
             .also { logger.info("Fant ${it.size} utsatte oppgaver som har timet ut hvor vi skal opprette en oppgave i gosys") }
 }


### PR DESCRIPTION
Setter timeout tilbake til normal etter økning i https://github.com/navikt/syfoinntektsmelding/pull/601 og https://github.com/navikt/syfoinntektsmelding/pull/602. Denne ble økt etter problemer med replikering i Infotrygd som førte til problemer hos Spleis. Disse problemene er over for lengst.