### PR TITLE
Skru cpu ned og minne opp

### DIFF
--- a/deploy/dev.yml
+++ b/deploy/dev.yml
@@ -8,10 +8,16 @@ metadata:
 spec:
   strategy:
     type: Recreate
-  ingresses:
-    - https://spinosaurus.intern.dev.nav.no
   image: {{image}}
-  port: 8080
+  resources:
+    requests:
+      cpu: 50m
+      memory: 1024Mi
+    limits:
+      memory: 2048Mi
+  replicas:
+    max: 1
+    min: 1
   prometheus:
     enabled: false
     path: /metrics
@@ -27,15 +33,6 @@ spec:
     path: /health/is-ready
     periodSeconds: 10
     timeout: 1
-  replicas:
-    max: 1
-    min: 1
-  resources:
-    limits:
-      memory: 1024Mi
-    requests:
-      cpu: 500m
-      memory: 386Mi
 
   secureLogs:
     enabled: true

--- a/deploy/prod.yml
+++ b/deploy/prod.yml
@@ -9,7 +9,15 @@ spec:
   strategy:
     type: Recreate
   image: {{image}}
-  port: 8080
+  resources:
+    requests:
+      cpu: 50m
+      memory: 1024Mi
+    limits:
+      memory: 2048Mi
+  replicas:
+    max: 1
+    min: 1
   prometheus:
     enabled: true
     path: /metrics
@@ -24,15 +32,6 @@ spec:
     path: /health/is-ready
     periodSeconds: 10
     timeout: 2
-  replicas:
-    max: 1
-    min: 1
-  resources:
-    limits:
-      memory: 1024Mi
-    requests:
-      cpu: 500m
-      memory: 386Mi
 
   secureLogs:
     enabled: true


### PR DESCRIPTION
Ifølge https://console.nav.cloud.nais.io/team/helsearbeidsgiver/prod-gcp/app/spinosaurus/utilization så har appen mer CPU enn den trenger, men bruker vanligvis mer minne enn den ber om i dag.