### PR TITLE
Tillat tomt inntekt i IM fra nav.no

### DIFF
--- a/src/main/kotlin/no/nav/syfo/simba/MapInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/syfo/simba/MapInntektsmelding.kt
@@ -77,7 +77,7 @@ fun mapInntektsmelding(
                 ?.begrunnelse
                 ?.name
                 .orEmpty(),
-        beregnetInntekt = im.inntekt!!.beloep.toBigDecimal(),
+        beregnetInntekt = im.inntekt?.beloep?.toBigDecimal(),
         inntektsdato = im.inntekt?.inntektsdato,
         opphørAvNaturalYtelse =
             im.inntekt


### PR DESCRIPTION
Spleis har begynt å prosessere IM-er fra nav.no i sin egen flyet. Det åpner for at vi ikke lenger alltid må sende inntekt.