### PR TITLE
fjern orgnr dokarkiv tittel syfo

### DIFF
--- a/src/main/kotlin/no/nav/syfo/util/DokumentbeskrivelseUtils.kt
+++ b/src/main/kotlin/no/nav/syfo/util/DokumentbeskrivelseUtils.kt
@@ -5,7 +5,6 @@ import no.nav.syfo.domain.inntektsmelding.Inntektsmelding
 import no.nav.syfo.domain.tilKortFormat
 
 fun Inntektsmelding.tilDokumentbeskrivelse(): String {
-    val orgnr = this.arbeidsgiverOrgnummer.let { if (it.isNullOrBlank()) "(ingen orgnr)" else it }
     val agp = this.arbeidsgiverperioder.tilKortFormat().orDefault("(ingen agp)")
-    return "Inntektsmelding-$orgnr-$agp"
+    return "Inntektsmelding-$agp"
 }

--- a/src/test/kotlin/no/nav/syfo/service/BehandleInngaaendeJournalConsumerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/service/BehandleInngaaendeJournalConsumerTest.kt
@@ -42,7 +42,7 @@ class BehandleInngaaendeJournalConsumerTest {
                 dokumentId = "dokumentId",
                 journalpostId = "journalpostId",
             )
-        val dokumentTittel = "Inntektsmelding-(ingen orgnr)-01.01.2019 - 01.02.2019"
+        val dokumentTittel = "Inntektsmelding-01.01.2019 - 01.02.2019"
         behandleInngaaendeJournalConsumer.oppdaterJournalpost(grunnleggendeInntektsmelding.copy(arbeidsgiverOrgnummer = null), inngaendeJournalpost, false)
         coVerifySequence {
             dokArkivClient.oppdaterJournalpost("journalpostId", match { it.dokumenter!!.first().tittel == dokumentTittel }, any())

--- a/src/test/kotlin/no/nav/syfo/util/DokumentbeskrivelseUtilsTest.kt
+++ b/src/test/kotlin/no/nav/syfo/util/DokumentbeskrivelseUtilsTest.kt
@@ -8,31 +8,31 @@ class DokumentbeskrivelseUtilsTest {
     @Test
     fun `1 agp i dokumentbeskrivelse`() {
         assertThat(grunnleggendeInntektsmelding.tilDokumentbeskrivelse())
-            .isEqualTo("Inntektsmelding-1234-01.01.2019 - 01.02.2019")
+            .isEqualTo("Inntektsmelding-01.01.2019 - 01.02.2019")
     }
 
     @Test
     fun `2 agp i dokumentbeskrivelse`() {
         val periode = grunnleggendeInntektsmelding.arbeidsgiverperioder.first()
         assertThat(grunnleggendeInntektsmelding.copy(arbeidsgiverperioder = listOf(periode, periode)).tilDokumentbeskrivelse())
-            .isEqualTo("Inntektsmelding-1234-01.01.2019 - [...] - 01.02.2019")
+            .isEqualTo("Inntektsmelding-01.01.2019 - [...] - 01.02.2019")
     }
 
     @Test
     fun `ingen agp i dokumentbeskrivelse`() {
         assertThat(grunnleggendeInntektsmelding.copy(arbeidsgiverperioder = emptyList()).tilDokumentbeskrivelse())
-            .isEqualTo("Inntektsmelding-1234-(ingen agp)")
+            .isEqualTo("Inntektsmelding-(ingen agp)")
     }
 
     @Test
     fun `ingen orgnr i dokumentbeskrivelse`() {
         assertThat(grunnleggendeInntektsmelding.copy(arbeidsgiverOrgnummer = null).tilDokumentbeskrivelse())
-            .isEqualTo("Inntektsmelding-(ingen orgnr)-01.01.2019 - 01.02.2019")
+            .isEqualTo("Inntektsmelding-01.01.2019 - 01.02.2019")
     }
 
     @Test
     fun `tom string orgnr i dokumentbeskrivelse`() {
         assertThat(grunnleggendeInntektsmelding.copy(arbeidsgiverOrgnummer = "").tilDokumentbeskrivelse())
-            .isEqualTo("Inntektsmelding-(ingen orgnr)-01.01.2019 - 01.02.2019")
+            .isEqualTo("Inntektsmelding-01.01.2019 - 01.02.2019")
     }
 }


### PR DESCRIPTION
Testet i `https://gosys-q1.dev.intern.nav.no/gosys/bruker/brukeroversikt.jsf` at orgnr er fjernet fra dokumentbeskrivelse

![image](https://github.com/user-attachments/assets/a481a7db-f02b-4a29-a49f-8361d9383edd)
