### PR TITLE
Fiks nullpointer for tom beregnetInntekt

### DIFF
--- a/src/main/kotlin/no/nav/syfo/utsattoppgave/BehandlingsKategori.kt
+++ b/src/main/kotlin/no/nav/syfo/utsattoppgave/BehandlingsKategori.kt
@@ -40,17 +40,26 @@ fun finnBehandlingsKategori(
 ): BehandlingsKategori =
     when {
         inntektsmelding.begrunnelseRedusert == "IkkeFravaer" -> BehandlingsKategori.IKKE_FRAVAER
+
         speilRelatert -> BehandlingsKategori.SPEIL_RELATERT
+
         gjelderUtland -> BehandlingsKategori.UTLAND
+
         inntektsmelding.begrunnelseRedusert == "BetvilerArbeidsufoerhet" -> BehandlingsKategori.BESTRIDER_SYKEMELDING
+
         inntektsmelding.refusjon.beloepPrMnd == null ||
             inntektsmelding.refusjon.beloepPrMnd <
             BigDecimal(
                 1,
             )
         -> BehandlingsKategori.IKKE_REFUSJON
+
         inntektsmelding.refusjon.opphoersdato != null -> BehandlingsKategori.REFUSJON_MED_DATO
+
+        inntektsmelding.beregnetInntekt == null -> BehandlingsKategori.REFUSJON_UTEN_DATO
+
         inntektsmelding.refusjon.beloepPrMnd < inntektsmelding.beregnetInntekt -> BehandlingsKategori.REFUSJON_LITEN_LØNN
+
         else -> BehandlingsKategori.REFUSJON_UTEN_DATO
     }
 

--- a/src/test/kotlin/no/nav/syfo/utsattoppgave/FinnBehandlingsKategoriTest.kt
+++ b/src/test/kotlin/no/nav/syfo/utsattoppgave/FinnBehandlingsKategoriTest.kt
@@ -106,9 +106,27 @@ internal class FinnBehandlingsKategoriTest {
         )
     }
 
+    @Test
+    fun inntekt_null() {
+        val inntektsmelding = mockInntektsmelding(Refusjon(beloepPrMnd = BigDecimal(17000.21), null), null)
+        assertEquals(
+            BehandlingsKategori.REFUSJON_UTEN_DATO,
+            finnBehandlingsKategori(inntektsmelding = inntektsmelding, speilRelatert = false, gjelderUtland = false),
+        )
+    }
+
+    @Test
+    fun refusjon_og_inntekt_null() {
+        val inntektsmelding = mockInntektsmelding(Refusjon(beloepPrMnd = null, null), null)
+        assertEquals(
+            BehandlingsKategori.IKKE_REFUSJON,
+            finnBehandlingsKategori(inntektsmelding = inntektsmelding, speilRelatert = false, gjelderUtland = false),
+        )
+    }
+
     fun mockInntektsmelding(
         refusjon: Refusjon,
-        inntekt: BigDecimal,
+        inntekt: BigDecimal?,
     ): Inntektsmelding =
         Inntektsmelding(
             id = "",


### PR DESCRIPTION
Java.BigDecimal sin implementasjon av < skjuler at de verdiene vi sammenlikner kan være null. Legger på eksplisitt null-sjekk.