### PR TITLE
Sett manuelt korrigert uansett om det er liste eller ikke

### DIFF
--- a/src/main/kotlin/no/nav/syfo/simba/MapInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/syfo/simba/MapInntektsmelding.kt
@@ -107,9 +107,9 @@ private fun NaturalytelseV1.tilNaturalytelse(): OpphoerAvNaturalytelse =
     )
 
 private fun Inntekt.tilRapportertInntekt(): RapportertInntekt {
-    val spinnEndringAarsak = endringAarsak?.tilSpinnInntektEndringAarsak()
     val spinnEndringAarsaker = endringAarsaker.orEmpty().map { it.tilSpinnInntektEndringAarsak() }
-    val erManueltKorrigert = spinnEndringAarsaker.isNotEmpty() || spinnEndringAarsak != null
+    val spinnEndringAarsak = endringAarsak?.tilSpinnInntektEndringAarsak() ?: spinnEndringAarsaker.firstOrNull()
+    val erManueltKorrigert = spinnEndringAarsaker.isNotEmpty()
 
     return RapportertInntekt(
         bekreftet = true,

--- a/src/main/kotlin/no/nav/syfo/simba/MapInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/syfo/simba/MapInntektsmelding.kt
@@ -109,6 +109,7 @@ private fun NaturalytelseV1.tilNaturalytelse(): OpphoerAvNaturalytelse =
 private fun Inntekt.tilRapportertInntekt(): RapportertInntekt {
     val spinnEndringAarsak = endringAarsak?.tilSpinnInntektEndringAarsak()
     val spinnEndringAarsaker = endringAarsaker.orEmpty().map { it.tilSpinnInntektEndringAarsak() }
+    val erManueltKorrigert = spinnEndringAarsaker.isNotEmpty() || spinnEndringAarsak != null
 
     return RapportertInntekt(
         bekreftet = true,
@@ -116,7 +117,7 @@ private fun Inntekt.tilRapportertInntekt(): RapportertInntekt {
         endringAarsak = spinnEndringAarsak?.aarsak,
         endringAarsakData = spinnEndringAarsak,
         endringAarsakerData = spinnEndringAarsaker,
-        manueltKorrigert = endringAarsak != null,
+        manueltKorrigert = erManueltKorrigert,
     )
 }
 

--- a/src/main/kotlin/no/nav/syfo/simba/MapInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/syfo/simba/MapInntektsmelding.kt
@@ -109,7 +109,6 @@ private fun NaturalytelseV1.tilNaturalytelse(): OpphoerAvNaturalytelse =
 private fun Inntekt.tilRapportertInntekt(): RapportertInntekt {
     val spinnEndringAarsaker = endringAarsaker.orEmpty().map { it.tilSpinnInntektEndringAarsak() }
     val spinnEndringAarsak = endringAarsak?.tilSpinnInntektEndringAarsak() ?: spinnEndringAarsaker.firstOrNull()
-    val erManueltKorrigert = spinnEndringAarsaker.isNotEmpty()
 
     return RapportertInntekt(
         bekreftet = true,
@@ -117,7 +116,7 @@ private fun Inntekt.tilRapportertInntekt(): RapportertInntekt {
         endringAarsak = spinnEndringAarsak?.aarsak,
         endringAarsakData = spinnEndringAarsak,
         endringAarsakerData = spinnEndringAarsaker,
-        manueltKorrigert = erManueltKorrigert,
+        manueltKorrigert = spinnEndringAarsaker.isNotEmpty(),
     )
 }
 

--- a/src/test/kotlin/no/nav/syfo/mapping/InntektsmeldingKontraktMapperKtTest.kt
+++ b/src/test/kotlin/no/nav/syfo/mapping/InntektsmeldingKontraktMapperKtTest.kt
@@ -99,7 +99,7 @@ class InntektsmeldingKontraktMapperKtTest {
                 "bekreftet": true,
                 "endringAarsak": null,
                 "beregnetInntekt": 49000.0,
-                "manueltKorrigert": false,
+                "manueltKorrigert": true,
                 "endringAarsakData": {
                     "aarsak": "NyStillingsprosent",
                     "bleKjent": null,
@@ -110,6 +110,8 @@ class InntektsmeldingKontraktMapperKtTest {
             """.trimIndent()
         val rapportertInntekt = om.readValue(rapportertInntektJson, RapportertInntekt::class.java)
         assertThat(rapportertInntekt.endringAarsakerData).isNotEmpty()
+        assertThat(rapportertInntekt.manueltKorrigert).isTrue()
+        assertThat(rapportertInntekt.endringAarsakData?.aarsak).isEqualTo("NyStillingsprosent")
         assertThat(rapportertInntekt.endringAarsakerData.first().aarsak).isEqualTo("NyStillingsprosent")
         assertThat(rapportertInntekt.endringAarsakerData.first().gjelderFra).isEqualTo("2024-11-01")
         assertThat(rapportertInntekt.endringAarsakerData.first().bleKjent).isNull()


### PR DESCRIPTION
Det viser seg at vi har innført en feil ved flere begrunnelser der man setter manuelt korrigert til false selv om den skal være true.