### PR TITLE
Fjern unødvendig matcher spleis funksjonalitet

### DIFF
--- a/src/main/kotlin/no/nav/syfo/domain/inntektsmelding/Inntektsmelding.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/inntektsmelding/Inntektsmelding.kt
@@ -2,7 +2,6 @@ package no.nav.syfo.domain.inntektsmelding
 
 import no.nav.syfo.domain.JournalStatus
 import no.nav.syfo.domain.Periode
-import no.nav.syfo.simba.Avsender.NAV_NO_SELVBESTEMT
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -74,7 +73,4 @@ data class Inntektsmelding(
                 arsakTilInnsending = this.arsakTilInnsending,
             ),
         )
-
-    // TODO: kanskje kan vi fjerne dette, hvis vedtaksperiodeId *alltid* skal komme i selvbestemtIM
-    fun matcherSpleis(): Boolean = !(avsenderSystem.navn == NAV_NO_SELVBESTEMT && vedtaksperiodeId == null)
 }

--- a/src/main/kotlin/no/nav/syfo/simba/InntektsmeldingConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/simba/InntektsmeldingConsumer.kt
@@ -97,14 +97,6 @@ class InntektsmeldingConsumer(
         val arkivreferanse = "im_$journalpostId"
         val inntektsmelding = mapInntektsmelding(arkivreferanse, aktorid, journalpostId, inntektsmeldingFraSimba)
         val dto = inntektsmeldingService.lagreBehandling(inntektsmelding, aktorid)
-        val matcherSpleis = inntektsmelding.matcherSpleis()
-        val timeout =
-            if (matcherSpleis) {
-                LocalDateTime.now().plusHours(OPPRETT_OPPGAVE_FORSINKELSE)
-            } else {
-                sikkerlogger.info("Mottok selvbestemtIM uten vedtaksperiode med journalpostId $journalpostId, oppretter gosys-oppgave umiddelbart")
-                LocalDateTime.now()
-            }
         utsattOppgaveService.opprett(
             UtsattOppgaveEntitet(
                 fnr = inntektsmelding.fnr,
@@ -113,7 +105,7 @@ class InntektsmeldingConsumer(
                 arkivreferanse = inntektsmelding.arkivRefereranse,
                 inntektsmeldingId = dto.uuid,
                 tilstand = Tilstand.Utsatt,
-                timeout = timeout,
+                timeout = LocalDateTime.now().plusHours(OPPRETT_OPPGAVE_FORSINKELSE),
                 gosysOppgaveId = null,
                 oppdatert = null,
                 speil = false,
@@ -128,7 +120,6 @@ class InntektsmeldingConsumer(
                 validerInntektsmelding(inntektsmelding),
                 arkivreferanse,
                 dto.uuid,
-                matcherSpleis,
             )
 
         inntektsmeldingAivenProducer.leggMottattInntektsmeldingPåTopics(mappedInntektsmelding)

--- a/src/test/kotlin/no/nav/syfo/TestData.kt
+++ b/src/test/kotlin/no/nav/syfo/TestData.kt
@@ -2,6 +2,7 @@ package no.nav.syfo
 
 import no.nav.syfo.domain.JournalStatus
 import no.nav.syfo.domain.Periode
+import no.nav.syfo.domain.inntektsmelding.AvsenderSystem
 import no.nav.syfo.domain.inntektsmelding.Inntektsmelding
 import java.time.LocalDate
 
@@ -22,4 +23,5 @@ val grunnleggendeInntektsmelding =
         arkivRefereranse = "AR123",
         førsteFraværsdag = LocalDate.of(2019, 10, 5),
         mottattDato = LocalDate.of(2019, 10, 25).atStartOfDay(),
+        avsenderSystem = AvsenderSystem("NAV_NO", "1.0"),
     )

--- a/src/test/kotlin/no/nav/syfo/domain/inntektsmelding/InntektsmeldingTest.kt
+++ b/src/test/kotlin/no/nav/syfo/domain/inntektsmelding/InntektsmeldingTest.kt
@@ -3,7 +3,6 @@ package no.nav.syfo.domain.inntektsmelding
 import no.nav.syfo.domain.JournalStatus
 import no.nav.syfo.domain.Periode
 import no.nav.syfo.repository.buildIM
-import no.nav.syfo.simba.Avsender
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -12,7 +11,6 @@ import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.UUID
 
 class InntektsmeldingTest {
     val im1 = buildIM().copy(bruttoUtbetalt = BigDecimal(100))
@@ -80,47 +78,5 @@ class InntektsmeldingTest {
         assertTrue(im1.copy(innsendingstidspunkt = LocalDateTime.now()).isDuplicate(im1))
         assertFalse(im1.copy(bruttoUtbetalt = BigDecimal(123)).isDuplicate(im1))
         assertFalse(im1.copy(årsakEndring = "qwe").isDuplicate(im1))
-    }
-
-    @Test
-    fun `selvbestemt matcher spleis bare hvis vedtaksperiodeId er satt`() {
-        val selvbestemtUtenVedtaksperiodeId =
-            im1.copy(
-                vedtaksperiodeId = null,
-                avsenderSystem = AvsenderSystem(Avsender.NAV_NO_SELVBESTEMT),
-            )
-        val selvbestemtMedVedtaksperiodeId =
-            im1.copy(
-                vedtaksperiodeId = UUID.randomUUID(),
-                avsenderSystem = AvsenderSystem(Avsender.NAV_NO_SELVBESTEMT),
-            )
-        assertFalse(selvbestemtUtenVedtaksperiodeId.matcherSpleis())
-        assertTrue(selvbestemtMedVedtaksperiodeId.matcherSpleis())
-    }
-
-    @Test
-    fun `Alle avsendere bortsett fra selvbestemt matcher alltid spleis som default`() {
-        val imFraSimbaUtenVedtaksperiodeId = im1.copy(vedtaksperiodeId = null, avsenderSystem = AvsenderSystem(Avsender.NAV_NO))
-        val imFraSimbaMedVedtaksperiodeId = im1.copy(vedtaksperiodeId = UUID.randomUUID(), avsenderSystem = AvsenderSystem(Avsender.NAV_NO))
-        val imFraEksterntSystemUtenVedtaksperiodeId =
-            im1.copy(
-                vedtaksperiodeId = null,
-                avsenderSystem = AvsenderSystem("Whatever Payment Co"),
-            )
-        val imFraEksterntSystemMedVedtaksperiodeId =
-            im1.copy(
-                vedtaksperiodeId = UUID.randomUUID(),
-                avsenderSystem = AvsenderSystem("Donald Duck & Co"),
-            )
-        val selvbestemtUtenVedtaksperiodeId =
-            im1.copy(
-                vedtaksperiodeId = null,
-                avsenderSystem = AvsenderSystem(Avsender.NAV_NO_SELVBESTEMT),
-            )
-        assertTrue(imFraSimbaUtenVedtaksperiodeId.matcherSpleis())
-        assertTrue(imFraSimbaMedVedtaksperiodeId.matcherSpleis())
-        assertTrue(imFraEksterntSystemUtenVedtaksperiodeId.matcherSpleis())
-        assertTrue(imFraEksterntSystemMedVedtaksperiodeId.matcherSpleis())
-        assertFalse(selvbestemtUtenVedtaksperiodeId.matcherSpleis())
     }
 }

--- a/src/test/kotlin/no/nav/syfo/mapping/InntektsmeldingMapperFraInternSyfoTilHAGKontraktTest.kt
+++ b/src/test/kotlin/no/nav/syfo/mapping/InntektsmeldingMapperFraInternSyfoTilHAGKontraktTest.kt
@@ -9,7 +9,6 @@ import no.nav.syfo.domain.inntektsmelding.RapportertInntekt
 import no.nav.syfo.domain.inntektsmelding.SpinnInntektEndringAarsak
 import no.nav.syfo.grunnleggendeInntektsmelding
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -112,22 +111,6 @@ class InntektsmeldingMapperFraInternSyfoTilHAGKontraktTest {
                 UUID.randomUUID().toString(),
             )
         assertEquals(vedtaksperiodeId, kontraktIMMedVedtaksperiodeId.vedtaksperiodeId)
-    }
-
-    @Test
-    fun mapInntektsmeldingKontraktSelvbestemtMatcherIkkeSpleis() {
-        val inntektsmelding = grunnleggendeInntektsmelding
-        val kontraktIM =
-            mapInntektsmeldingKontrakt(inntektsmelding, "123", Gyldighetsstatus.GYLDIG, "arkivref123", UUID.randomUUID().toString(), false)
-        assertFalse(kontraktIM.matcherSpleis)
-    }
-
-    @Test
-    fun mapInntektsmeldingKontraktMatcherSpleisSomDefault() {
-        val inntektsmelding = grunnleggendeInntektsmelding
-        val kontraktIM =
-            mapInntektsmeldingKontrakt(inntektsmelding, "123", Gyldighetsstatus.GYLDIG, "arkivref123", UUID.randomUUID().toString())
-        assertTrue(kontraktIM.matcherSpleis)
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Forenkle funskjonalitet som setter matcher spleis siden vi alltid setter denne til true fra portalen uavhengig om det er selvbestemt eller forespurt inntektsmelding