### PR TITLE
gosys oppgave legg til beskrivelse

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelse.kt
@@ -5,19 +5,15 @@ import no.nav.syfo.domain.inntektsmelding.Inntektsmelding
 import no.nav.syfo.domain.tilKortFormat
 import no.nav.syfo.domain.tilNorskFormat
 import no.nav.syfo.utsattoppgave.BehandlingsKategori
-import java.math.BigDecimal
 
 fun lagInntektsmeldingOppgaveBeskrivelse(
-    inntektsmelding: Inntektsmelding?,
+    inntektsmelding: Inntektsmelding,
     behandlingsKategori: BehandlingsKategori,
 ): String {
-    if (inntektsmelding == null) {
-        return "Det har kommet en inntektsmelding på sykepenger."
-    }
-
     val linjer =
         buildList {
             add("Inntektsmelding sykepenger")
+            add("Utdrag av info, se vedlagt inntektsmeldingen (PDF) for full informasjon.")
             add("Kategori: ${behandlingsKategori.oppgaveBeskrivelse ?: behandlingsKategori.name}")
 
             add("")
@@ -28,7 +24,7 @@ fun lagInntektsmeldingOppgaveBeskrivelse(
             inntektsmelding.beregnetInntekt?.let { add("Beregnet månedslønn: $it kr") }
 
             val refusjon = inntektsmelding.refusjon
-            if (refusjon.beloepPrMnd != null && refusjon.beloepPrMnd > BigDecimal.ZERO) {
+            if (refusjon.beloepPrMnd != null) {
                 add("Refusjon: ${refusjon.beloepPrMnd} kr/mnd")
                 refusjon.opphoersdato?.let { add("Refusjon opphører: ${it.tilNorskFormat()}") }
             } else {

--- a/src/main/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelse.kt
@@ -30,7 +30,6 @@ fun lagInntektsmeldingOppgaveBeskrivelse(
                 // førsteFraværsdag koden kan slettes når ingen utsatt oppgave er av typen Altinn2 inntektsmelding
                 add("Bestemmende fraværsdag: ${inntektsmelding.førsteFraværsdag.tilNorskFormat()}")
             }
-            inntektsmelding.inntektsdato?.let { add("Inntektsdato: ${it.tilNorskFormat()}") }
             add("Arbeidsgiverperiode: ${inntektsmelding.arbeidsgiverperioder.tilKortFormat().orDefault("Ingen")}")
 
             add("")

--- a/src/main/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelse.kt
@@ -37,14 +37,14 @@ fun lagInntektsmeldingOppgaveBeskrivelse(
             inntektsmelding.beregnetInntekt?.let { add("Beregnet månedslønn: ${it.tilNorskFormat()} kr") }
 
             if (refusjon.beloepPrMnd != null) {
-                add("Refusjon: ${refusjon.beloepPrMnd} kr/mnd")
+                add("Refusjon: ${refusjon.beloepPrMnd.tilNorskFormat()} kr/mnd")
                 refusjon.opphoersdato?.let { add("Refusjon opphører: ${it.tilNorskFormat()}") }
             } else {
                 add("Ingen refusjon - utbetaling til bruker")
             }
 
             inntektsmelding.endringerIRefusjon.forEach { endring ->
-                val beloep = endring.beloep?.let { "$it kr" } ?: "Ukjent beløp"
+                val beloep = endring.beloep?.let { "${it.tilNorskFormat()} kr" } ?: "Ukjent beløp"
                 val dato = endring.endringsdato?.let { " fra ${it.tilNorskFormat()}" }.orEmpty()
                 add("Endring i refusjon: $beloep$dato")
             }
@@ -55,7 +55,7 @@ fun lagInntektsmeldingOppgaveBeskrivelse(
 
             inntektsmelding.opphørAvNaturalYtelse.forEach { opphoer ->
                 val ytelse = opphoer.naturalytelse?.name ?: "Naturalytelse"
-                val beloep = opphoer.beloepPrMnd?.let { " ($it kr/mnd)" }.orEmpty()
+                val beloep = opphoer.beloepPrMnd?.let { " (${it.tilNorskFormat()} kr/mnd)" }.orEmpty()
                 val dato = opphoer.fom?.let { " fra ${it.tilNorskFormat()}" }.orEmpty()
                 add("Bortfall av naturalytelse: $ytelse$beloep$dato")
             }
@@ -74,7 +74,7 @@ private val inntektFormat =
     DecimalFormat(
         "#,##0.00",
         DecimalFormatSymbols().apply {
-            groupingSeparator = ' '
+            groupingSeparator = ' '
             decimalSeparator = ','
         },
     )

--- a/src/main/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelse.kt
@@ -12,9 +12,12 @@ fun lagInntektsmeldingOppgaveBeskrivelse(
 ): String {
     val linjer =
         buildList {
+            val refusjon = inntektsmelding.refusjon
+            val erRefusjon = refusjon.beloepPrMnd != null
+            val kategori = behandlingsKategori.oppgaveBeskrivelse ?: behandlingsKategori.name
+            add("Refusjon: ${if (erRefusjon) "Ja" else "Nei"} | Kategori: $kategori")
             add("Inntektsmelding sykepenger")
             add("Utdrag av info, se vedlagt inntektsmeldingen (PDF) for full informasjon.")
-            add("Kategori: ${behandlingsKategori.oppgaveBeskrivelse ?: behandlingsKategori.name}")
 
             add("")
             inntektsmelding.førsteFraværsdag?.let { add("Bestemmende fraværsdag: ${it.tilNorskFormat()}") }
@@ -23,7 +26,6 @@ fun lagInntektsmeldingOppgaveBeskrivelse(
             add("")
             inntektsmelding.beregnetInntekt?.let { add("Beregnet månedslønn: $it kr") }
 
-            val refusjon = inntektsmelding.refusjon
             if (refusjon.beloepPrMnd != null) {
                 add("Refusjon: ${refusjon.beloepPrMnd} kr/mnd")
                 refusjon.opphoersdato?.let { add("Refusjon opphører: ${it.tilNorskFormat()}") }

--- a/src/main/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelse.kt
@@ -1,14 +1,14 @@
 package no.nav.syfo.client.oppgave
 
-import java.math.BigDecimal
-import java.math.RoundingMode
-import java.text.DecimalFormat
-import java.text.DecimalFormatSymbols
 import no.nav.helsearbeidsgiver.utils.pipe.orDefault
 import no.nav.syfo.domain.inntektsmelding.Inntektsmelding
 import no.nav.syfo.domain.tilKortFormat
 import no.nav.syfo.domain.tilNorskFormat
 import no.nav.syfo.utsattoppgave.BehandlingsKategori
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
 
 fun lagInntektsmeldingOppgaveBeskrivelse(
     inntektsmelding: Inntektsmelding,
@@ -68,7 +68,6 @@ fun lagInntektsmeldingOppgaveBeskrivelse(
 
     return linjer.joinToString("\n")
 }
-
 
 private val inntektFormat =
     DecimalFormat(

--- a/src/main/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelse.kt
@@ -1,5 +1,9 @@
 package no.nav.syfo.client.oppgave
 
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
 import no.nav.helsearbeidsgiver.utils.pipe.orDefault
 import no.nav.syfo.domain.inntektsmelding.Inntektsmelding
 import no.nav.syfo.domain.tilKortFormat
@@ -17,14 +21,20 @@ fun lagInntektsmeldingOppgaveBeskrivelse(
             val kategori = behandlingsKategori.oppgaveBeskrivelse ?: behandlingsKategori.name
             add("Refusjon: ${if (erRefusjon) "Ja" else "Nei"} | Kategori: $kategori")
             add("Inntektsmelding sykepenger")
-            add("Utdrag av info, se vedlagt inntektsmeldingen (PDF) for full informasjon.")
+            add("Utdrag av info, se vedlagt inntektsmelding (PDF) for full informasjon.")
 
             add("")
-            inntektsmelding.førsteFraværsdag?.let { add("Bestemmende fraværsdag: ${it.tilNorskFormat()}") }
+            if (inntektsmelding.inntektsdato != null) {
+                add("Inntektsdato: ${inntektsmelding.inntektsdato.tilNorskFormat()}")
+            } else if (inntektsmelding.førsteFraværsdag != null) {
+                // førsteFraværsdag koden kan slettes når ingen utsatt oppgave er av typen Altinn2 inntektsmelding
+                add("Bestemmende fraværsdag: ${inntektsmelding.førsteFraværsdag.tilNorskFormat()}")
+            }
+            inntektsmelding.inntektsdato?.let { add("Inntektsdato: ${it.tilNorskFormat()}") }
             add("Arbeidsgiverperiode: ${inntektsmelding.arbeidsgiverperioder.tilKortFormat().orDefault("Ingen")}")
 
             add("")
-            inntektsmelding.beregnetInntekt?.let { add("Beregnet månedslønn: $it kr") }
+            inntektsmelding.beregnetInntekt?.let { add("Beregnet månedslønn: ${it.tilNorskFormat()} kr") }
 
             if (refusjon.beloepPrMnd != null) {
                 add("Refusjon: ${refusjon.beloepPrMnd} kr/mnd")
@@ -34,8 +44,8 @@ fun lagInntektsmeldingOppgaveBeskrivelse(
             }
 
             inntektsmelding.endringerIRefusjon.forEach { endring ->
-                val beloep = endring.beloep?.let { "$it kr" } ?: "ukjent beløp"
-                val dato = endring.endringsdato?.let { " fra ${it.tilNorskFormat()}" } ?: ""
+                val beloep = endring.beloep?.let { "$it kr" } ?: "Ukjent beløp"
+                val dato = endring.endringsdato?.let { " fra ${it.tilNorskFormat()}" }.orEmpty()
                 add("Endring i refusjon: $beloep$dato")
             }
 
@@ -45,8 +55,8 @@ fun lagInntektsmeldingOppgaveBeskrivelse(
 
             inntektsmelding.opphørAvNaturalYtelse.forEach { opphoer ->
                 val ytelse = opphoer.naturalytelse?.name ?: "Naturalytelse"
-                val beloep = opphoer.beloepPrMnd?.let { " ($it kr/mnd)" } ?: ""
-                val dato = opphoer.fom?.let { " fra ${it.tilNorskFormat()}" } ?: ""
+                val beloep = opphoer.beloepPrMnd?.let { " ($it kr/mnd)" }.orEmpty()
+                val dato = opphoer.fom?.let { " fra ${it.tilNorskFormat()}" }.orEmpty()
                 add("Bortfall av naturalytelse: $ytelse$beloep$dato")
             }
 
@@ -58,3 +68,17 @@ fun lagInntektsmeldingOppgaveBeskrivelse(
 
     return linjer.joinToString("\n")
 }
+
+
+private val inntektFormat =
+    DecimalFormat(
+        "#,##0.00",
+        DecimalFormatSymbols().apply {
+            groupingSeparator = ' '
+            decimalSeparator = ','
+        },
+    )
+
+fun BigDecimal.tilNorskFormat(): String =
+    setScale(2, RoundingMode.HALF_UP)
+        .let(inntektFormat::format)

--- a/src/main/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelse.kt
@@ -1,0 +1,62 @@
+package no.nav.syfo.client.oppgave
+
+import no.nav.helsearbeidsgiver.utils.pipe.orDefault
+import no.nav.syfo.domain.inntektsmelding.Inntektsmelding
+import no.nav.syfo.domain.tilKortFormat
+import no.nav.syfo.domain.tilNorskFormat
+import no.nav.syfo.utsattoppgave.BehandlingsKategori
+import java.math.BigDecimal
+
+fun lagInntektsmeldingOppgaveBeskrivelse(
+    inntektsmelding: Inntektsmelding?,
+    behandlingsKategori: BehandlingsKategori,
+): String {
+    if (inntektsmelding == null) {
+        return "Det har kommet en inntektsmelding på sykepenger."
+    }
+
+    val linjer =
+        buildList {
+            add("Inntektsmelding sykepenger")
+            add("Kategori: ${behandlingsKategori.oppgaveBeskrivelse ?: behandlingsKategori.name}")
+
+            add("")
+            inntektsmelding.førsteFraværsdag?.let { add("Bestemmende fraværsdag: ${it.tilNorskFormat()}") }
+            add("Arbeidsgiverperiode: ${inntektsmelding.arbeidsgiverperioder.tilKortFormat().orDefault("Ingen")}")
+
+            add("")
+            inntektsmelding.beregnetInntekt?.let { add("Beregnet månedslønn: $it kr") }
+
+            val refusjon = inntektsmelding.refusjon
+            if (refusjon.beloepPrMnd != null && refusjon.beloepPrMnd > BigDecimal.ZERO) {
+                add("Refusjon: ${refusjon.beloepPrMnd} kr/mnd")
+                refusjon.opphoersdato?.let { add("Refusjon opphører: ${it.tilNorskFormat()}") }
+            } else {
+                add("Ingen refusjon - utbetaling til bruker")
+            }
+
+            inntektsmelding.endringerIRefusjon.forEach { endring ->
+                val beloep = endring.beloep?.let { "$it kr" } ?: "ukjent beløp"
+                val dato = endring.endringsdato?.let { " fra ${it.tilNorskFormat()}" } ?: ""
+                add("Endring i refusjon: $beloep$dato")
+            }
+
+            if (inntektsmelding.begrunnelseRedusert.isNotEmpty()) {
+                add("Begrunnelse redusert AGP: ${inntektsmelding.begrunnelseRedusert}")
+            }
+
+            inntektsmelding.opphørAvNaturalYtelse.forEach { opphoer ->
+                val ytelse = opphoer.naturalytelse?.name ?: "Naturalytelse"
+                val beloep = opphoer.beloepPrMnd?.let { " ($it kr/mnd)" } ?: ""
+                val dato = opphoer.fom?.let { " fra ${it.tilNorskFormat()}" } ?: ""
+                add("Bortfall av naturalytelse: $ytelse$beloep$dato")
+            }
+
+            add("")
+            add("Forespurt: ${if (inntektsmelding.forespurt) "Ja" else "Nei"}")
+            if (inntektsmelding.nærRelasjon == true) add("Nær relasjon: Ja")
+            if (inntektsmelding.harFlereArbeidsforhold) add("Flere arbeidsforhold: Ja")
+        }
+
+    return linjer.joinToString("\n")
+}

--- a/src/main/kotlin/no/nav/syfo/client/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/syfo/client/oppgave/OppgaveService.kt
@@ -66,7 +66,7 @@ class OppgaveService(
         journalpostId: String,
         aktoerId: String,
         behandlingsKategori: BehandlingsKategori,
-        inntektsmelding: Inntektsmelding? = null,
+        oppgaveBeskrivelse: String,
     ): OppgaveResultat {
         val eksisterendeOppgave = hentHvisOppgaveFinnes(Oppgavetype.INNTEKTSMELDING, journalpostId)
         metrikk.tellOpprettOppgave(eksisterendeOppgave != null)
@@ -83,7 +83,7 @@ class OppgaveService(
                 aktoerId = aktoerId,
                 journalpostId = journalpostId,
                 behandlesAvApplikasjon = "FS22",
-                beskrivelse = lagInntektsmeldingOppgaveBeskrivelse(inntektsmelding, behandlingsKategori),
+                beskrivelse = oppgaveBeskrivelse,
                 tema = Tema.SYK,
                 oppgavetype = Oppgavetype.INNTEKTSMELDING,
                 behandlingstype = behandlingsKategori.getBehandlingsType(),

--- a/src/main/kotlin/no/nav/syfo/client/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/syfo/client/oppgave/OppgaveService.kt
@@ -15,6 +15,7 @@ import no.nav.syfo.behandling.OpprettFordelingsOppgaveException
 import no.nav.syfo.behandling.OpprettOppgaveException
 import no.nav.syfo.domain.OppgaveResultat
 import no.nav.syfo.util.Metrikk
+import no.nav.syfo.domain.inntektsmelding.Inntektsmelding
 import no.nav.syfo.utsattoppgave.BehandlingsKategori
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -65,6 +66,7 @@ class OppgaveService(
         journalpostId: String,
         aktoerId: String,
         behandlingsKategori: BehandlingsKategori,
+        inntektsmelding: Inntektsmelding? = null,
     ): OppgaveResultat {
         val eksisterendeOppgave = hentHvisOppgaveFinnes(Oppgavetype.INNTEKTSMELDING, journalpostId)
         metrikk.tellOpprettOppgave(eksisterendeOppgave != null)
@@ -81,7 +83,7 @@ class OppgaveService(
                 aktoerId = aktoerId,
                 journalpostId = journalpostId,
                 behandlesAvApplikasjon = "FS22",
-                beskrivelse = "Det har kommet en inntektsmelding på sykepenger.",
+                beskrivelse = lagInntektsmeldingOppgaveBeskrivelse(inntektsmelding, behandlingsKategori),
                 tema = Tema.SYK,
                 oppgavetype = Oppgavetype.INNTEKTSMELDING,
                 behandlingstype = behandlingsKategori.getBehandlingsType(),

--- a/src/main/kotlin/no/nav/syfo/client/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/syfo/client/oppgave/OppgaveService.kt
@@ -14,8 +14,8 @@ import no.nav.syfo.behandling.HentOppgaveException
 import no.nav.syfo.behandling.OpprettFordelingsOppgaveException
 import no.nav.syfo.behandling.OpprettOppgaveException
 import no.nav.syfo.domain.OppgaveResultat
-import no.nav.syfo.util.Metrikk
 import no.nav.syfo.domain.inntektsmelding.Inntektsmelding
+import no.nav.syfo.util.Metrikk
 import no.nav.syfo.utsattoppgave.BehandlingsKategori
 import java.time.DayOfWeek
 import java.time.LocalDate

--- a/src/main/kotlin/no/nav/syfo/domain/Periode.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/Periode.kt
@@ -19,4 +19,4 @@ fun List<Periode>.tilKortFormat(): String? =
 
 private val norskDatoFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
 
-private fun LocalDate.tilNorskFormat(): String = format(norskDatoFormat)
+fun LocalDate.tilNorskFormat(): String = format(norskDatoFormat)

--- a/src/main/kotlin/no/nav/syfo/prosesser/FinnAlleUtgaandeOppgaverProcessor.kt
+++ b/src/main/kotlin/no/nav/syfo/prosesser/FinnAlleUtgaandeOppgaverProcessor.kt
@@ -55,7 +55,7 @@ class FinnAlleUtgaandeOppgaverProcessor(
                                 if (behandlingsKategori != BehandlingsKategori.IKKE_FRAVAER) {
                                     logger.info("Skal opprette oppgave for inntektsmelding: ${oppgaveEntitet.arkivreferanse}")
 
-                                    val resultat = oppgaveService.opprettOppgaveIGosys(oppgaveEntitet, behandlingsKategori)
+                                    val resultat = oppgaveService.opprettOppgaveIGosys(oppgaveEntitet, behandlingsKategori, inntektsmelding)
 
                                     logger.info(
                                         "Oppgave opprettet i gosys pga timeout for inntektsmelding: ${oppgaveEntitet.arkivreferanse}",

--- a/src/main/kotlin/no/nav/syfo/utsattoppgave/UtsattOppgaveService.kt
+++ b/src/main/kotlin/no/nav/syfo/utsattoppgave/UtsattOppgaveService.kt
@@ -77,7 +77,7 @@ class UtsattOppgaveService(
                         val gjelderUtland = behandlendeEnhetConsumer.gjelderUtland(oppgave)
                         val behandlingsKategori = finnBehandlingsKategori(inntektsmelding, oppgave.speil, gjelderUtland)
                         if (behandlingsKategori != BehandlingsKategori.IKKE_FRAVAER) {
-                            val resultat = oppgaveService.opprettOppgaveIGosys(oppgave, behandlingsKategori)
+                            val resultat = oppgaveService.opprettOppgaveIGosys(oppgave, behandlingsKategori, inntektsmelding)
 
                             val oppdatertOppgave =
                                 oppgave.copy(
@@ -148,12 +148,14 @@ fun InntektsmeldingRepository.hentInntektsmelding(
 fun OppgaveService.opprettOppgaveIGosys(
     utsattOppgave: UtsattOppgaveEntitet,
     behandlingsKategori: BehandlingsKategori,
+    inntektsmelding: Inntektsmelding? = null,
 ): OppgaveResultat =
     runBlocking {
         opprettOppgave(
             journalpostId = utsattOppgave.journalpostId,
             aktoerId = utsattOppgave.aktørId,
             behandlingsKategori = behandlingsKategori,
+            inntektsmelding = inntektsmelding,
         )
     }
 

--- a/src/main/kotlin/no/nav/syfo/utsattoppgave/UtsattOppgaveService.kt
+++ b/src/main/kotlin/no/nav/syfo/utsattoppgave/UtsattOppgaveService.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.runBlocking
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import no.nav.syfo.client.oppgave.OppgaveService
+import no.nav.syfo.client.oppgave.lagInntektsmeldingOppgaveBeskrivelse
 import no.nav.syfo.domain.OppgaveResultat
 import no.nav.syfo.domain.inntektsmelding.Inntektsmelding
 import no.nav.syfo.dto.Tilstand
@@ -148,14 +149,14 @@ fun InntektsmeldingRepository.hentInntektsmelding(
 fun OppgaveService.opprettOppgaveIGosys(
     utsattOppgave: UtsattOppgaveEntitet,
     behandlingsKategori: BehandlingsKategori,
-    inntektsmelding: Inntektsmelding? = null,
+    inntektsmelding: Inntektsmelding,
 ): OppgaveResultat =
     runBlocking {
         opprettOppgave(
             journalpostId = utsattOppgave.journalpostId,
             aktoerId = utsattOppgave.aktørId,
             behandlingsKategori = behandlingsKategori,
-            inntektsmelding = inntektsmelding,
+            oppgaveBeskrivelse = lagInntektsmeldingOppgaveBeskrivelse(inntektsmelding, behandlingsKategori),
         )
     }
 

--- a/src/test/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelseTest.kt
+++ b/src/test/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelseTest.kt
@@ -15,19 +15,19 @@ class ImBeskrivelseTest {
             """
             Refusjon: Ja | Kategori: Utbetaling til bruker
             Inntektsmelding sykepenger
-            Utdrag av info, se vedlagt inntektsmeldingen (PDF) for full informasjon.
+            Utdrag av info, se vedlagt inntektsmelding (PDF) for full informasjon.
 
             Bestemmende fraværsdag: 10.02.2010
             Arbeidsgiverperiode: 01.11.2011 - [...] - 04.04.2014
 
-            Beregnet månedslønn: 999999999999 kr
-            Refusjon: 333333333333 kr/mnd
+            Beregnet månedslønn: 999 999 999 999,00 kr
+            Refusjon: 333 333 333 333,00 kr/mnd
             Refusjon opphører: 20.02.2020
-            Endring i refusjon: 555555555555 kr fra 05.05.2015
-            Endring i refusjon: 666666666666 kr fra 06.06.2016
+            Endring i refusjon: 555 555 555 555,00 kr fra 05.05.2015
+            Endring i refusjon: 666 666 666 666,00 kr fra 06.06.2016
             Begrunnelse redusert AGP: Grunn til reduksjon
-            Bortfall av naturalytelse: BIL (555555555555 kr/mnd) fra 05.05.2015
-            Bortfall av naturalytelse: TILSKUDDBARNEHAGEPLASS (666666666666 kr/mnd) fra 06.06.2016
+            Bortfall av naturalytelse: BIL (555 555 555 555,00 kr/mnd) fra 05.05.2015
+            Bortfall av naturalytelse: TILSKUDDBARNEHAGEPLASS (666 666 666 666,00 kr/mnd) fra 06.06.2016
 
             Forespurt: Nei
             """.trimIndent()
@@ -53,12 +53,12 @@ class ImBeskrivelseTest {
             """
             Refusjon: Nei | Kategori: Bestrider sykmelding
             Inntektsmelding sykepenger
-            Utdrag av info, se vedlagt inntektsmeldingen (PDF) for full informasjon.
+            Utdrag av info, se vedlagt inntektsmelding (PDF) for full informasjon.
 
             Bestemmende fraværsdag: 10.02.2010
             Arbeidsgiverperiode: Ingen
 
-            Beregnet månedslønn: 999999999999 kr
+            Beregnet månedslønn: 999 999 999 999,00 kr
             Ingen refusjon - utbetaling til bruker
 
             Forespurt: Ja

--- a/src/test/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelseTest.kt
+++ b/src/test/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelseTest.kt
@@ -13,9 +13,9 @@ class ImBeskrivelseTest {
 
         val forventet =
             """
+            Refusjon: Ja | Kategori: Utbetaling til bruker
             Inntektsmelding sykepenger
             Utdrag av info, se vedlagt inntektsmeldingen (PDF) for full informasjon.
-            Kategori: Utbetaling til bruker
 
             Bestemmende fraværsdag: 10.02.2010
             Arbeidsgiverperiode: 01.11.2011 - [...] - 04.04.2014
@@ -51,9 +51,9 @@ class ImBeskrivelseTest {
 
         val forventet =
             """
+            Refusjon: Nei | Kategori: Bestrider sykmelding
             Inntektsmelding sykepenger
             Utdrag av info, se vedlagt inntektsmeldingen (PDF) for full informasjon.
-            Kategori: Bestrider sykmelding
 
             Bestemmende fraværsdag: 10.02.2010
             Arbeidsgiverperiode: Ingen

--- a/src/test/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelseTest.kt
+++ b/src/test/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelseTest.kt
@@ -14,6 +14,7 @@ class ImBeskrivelseTest {
         val forventet =
             """
             Inntektsmelding sykepenger
+            Utdrag av info, se vedlagt inntektsmeldingen (PDF) for full informasjon.
             Kategori: Utbetaling til bruker
 
             Bestemmende fraværsdag: 10.02.2010
@@ -51,6 +52,7 @@ class ImBeskrivelseTest {
         val forventet =
             """
             Inntektsmelding sykepenger
+            Utdrag av info, se vedlagt inntektsmeldingen (PDF) for full informasjon.
             Kategori: Bestrider sykmelding
 
             Bestemmende fraværsdag: 10.02.2010

--- a/src/test/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelseTest.kt
+++ b/src/test/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelseTest.kt
@@ -1,0 +1,69 @@
+package no.nav.syfo.client.oppgave
+
+import no.nav.syfo.domain.inntektsmelding.Refusjon
+import no.nav.syfo.repository.buildIM
+import no.nav.syfo.utsattoppgave.BehandlingsKategori
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ImBeskrivelseTest {
+    @Test
+    fun `beskrivelse med refusjon`() {
+        val inntektsmelding = buildIM()
+
+        val forventet =
+            """
+            Inntektsmelding sykepenger
+            Kategori: Utbetaling til bruker
+
+            Bestemmende fraværsdag: 10.02.2010
+            Arbeidsgiverperiode: 01.11.2011 - [...] - 04.04.2014
+
+            Beregnet månedslønn: 999999999999 kr
+            Refusjon: 333333333333 kr/mnd
+            Refusjon opphører: 20.02.2020
+            Endring i refusjon: 555555555555 kr fra 05.05.2015
+            Endring i refusjon: 666666666666 kr fra 06.06.2016
+            Begrunnelse redusert AGP: Grunn til reduksjon
+            Bortfall av naturalytelse: BIL (555555555555 kr/mnd) fra 05.05.2015
+            Bortfall av naturalytelse: TILSKUDDBARNEHAGEPLASS (666666666666 kr/mnd) fra 06.06.2016
+
+            Forespurt: Nei
+            """.trimIndent()
+
+        assertEquals(forventet, lagInntektsmeldingOppgaveBeskrivelse(inntektsmelding, BehandlingsKategori.REFUSJON_MED_DATO))
+    }
+
+    @Test
+    fun `beskrivelse uten refusjon`() {
+        val inntektsmelding =
+            buildIM().copy(
+                arbeidsgiverperioder = emptyList(),
+                refusjon = Refusjon(),
+                endringerIRefusjon = emptyList(),
+                opphørAvNaturalYtelse = emptyList(),
+                begrunnelseRedusert = "",
+                forespurt = true,
+                nærRelasjon = true,
+                harFlereArbeidsforhold = true,
+            )
+
+        val forventet =
+            """
+            Inntektsmelding sykepenger
+            Kategori: Bestrider sykmelding
+
+            Bestemmende fraværsdag: 10.02.2010
+            Arbeidsgiverperiode: Ingen
+
+            Beregnet månedslønn: 999999999999 kr
+            Ingen refusjon - utbetaling til bruker
+
+            Forespurt: Ja
+            Nær relasjon: Ja
+            Flere arbeidsforhold: Ja
+            """.trimIndent()
+
+        assertEquals(forventet, lagInntektsmeldingOppgaveBeskrivelse(inntektsmelding, BehandlingsKategori.BESTRIDER_SYKEMELDING))
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/client/oppgave/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/client/oppgave/OppgaveServiceTest.kt
@@ -15,9 +15,12 @@ import no.nav.helsearbeidsgiver.oppgave.domain.OpprettOppgaveRequest
 import no.nav.helsearbeidsgiver.oppgave.domain.OpprettOppgaveResponse
 import no.nav.helsearbeidsgiver.oppgave.domain.Prioritet
 import no.nav.helsearbeidsgiver.oppgave.exception.OpprettOppgaveFeiletException
+import no.nav.syfo.UtsattOppgaveTestData
 import no.nav.syfo.behandling.OpprettOppgaveException
 import no.nav.syfo.domain.OppgaveResultat
+import no.nav.syfo.repository.buildIM
 import no.nav.syfo.utsattoppgave.BehandlingsKategori
+import no.nav.syfo.utsattoppgave.opprettOppgaveIGosys
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -91,8 +94,8 @@ class OppgaveServiceTest {
     @Test
     fun `skal ikke opprette oppgave dersom oppgave finnes fra før`() {
         val behandlingsKategori = BehandlingsKategori.UTLAND
-        val journalpostId = "123"
-        val aktoerId = "456"
+        val oppgave = UtsattOppgaveTestData.oppgave
+        val im = buildIM()
 
         coEvery { oppgaveClient.hentOppgaver(any()) } returns
             OppgaveListeResponse(
@@ -109,7 +112,7 @@ class OppgaveServiceTest {
 
         val result =
             runBlocking {
-                oppgaveService.opprettOppgave(journalpostId, aktoerId, behandlingsKategori)
+                oppgaveService.opprettOppgaveIGosys(oppgave, behandlingsKategori, im)
             }
 
         coVerify(exactly = 0) {
@@ -124,8 +127,8 @@ class OppgaveServiceTest {
 
     @Test
     fun `skal kaste feil når oppretteOppgave feiler`() {
-        val journalpostId = "123"
-        val aktoerId = "456"
+        val oppgave = UtsattOppgaveTestData.oppgave
+        val im = buildIM()
         val behandlingsKategori = BehandlingsKategori.REFUSJON_MED_DATO
         coEvery { oppgaveClient.hentOppgaver(any()) } returns OppgaveListeResponse(0, emptyList())
         coEvery {
@@ -137,7 +140,7 @@ class OppgaveServiceTest {
         val exception =
             assertThrows<OpprettOppgaveException> {
                 runBlocking {
-                    oppgaveService.opprettOppgave(journalpostId, aktoerId, behandlingsKategori)
+                    oppgaveService.opprettOppgaveIGosys(oppgave, behandlingsKategori, im)
                 }
             }
 
@@ -247,12 +250,12 @@ class OppgaveServiceTest {
     }
 
     private fun mockAndRunOpprettOppgave(behandlingsKategori: BehandlingsKategori): OppgaveResultat {
-        val journalpostId = "123"
-        val aktoerId = "456"
+        val oppgave = UtsattOppgaveTestData.oppgave
+        val im = buildIM()
 
         coEvery { oppgaveClient.hentOppgaver(any()) } returns OppgaveListeResponse(0, emptyList())
         coEvery { oppgaveClient.opprettOppgave(any<OpprettOppgaveRequest>()) } returns OpprettOppgaveResponse(1)
 
-        return runBlocking { oppgaveService.opprettOppgave(journalpostId, aktoerId, behandlingsKategori) }
+        return runBlocking { oppgaveService.opprettOppgaveIGosys(oppgave, behandlingsKategori, im) }
     }
 }

--- a/src/test/kotlin/no/nav/syfo/prosesser/FinnAlleUtgaandeOppgaverProcessorTest.kt
+++ b/src/test/kotlin/no/nav/syfo/prosesser/FinnAlleUtgaandeOppgaverProcessorTest.kt
@@ -43,7 +43,7 @@ class FinnAlleUtgaandeOppgaverProcessorTest {
     fun setup() {
         clearAllMocks()
         every { utsattOppgaveDAO.finnAlleUtgaatteOppgaver() } returns listOf(oppgave)
-        coEvery { oppgaveService.opprettOppgave(any(), any(), any()) } returns OppgaveResultat(Random.nextInt(), false, false)
+        coEvery { oppgaveService.opprettOppgave(any(), any(), any(), any()) } returns OppgaveResultat(Random.nextInt(), false, false)
         every { behandlendeEnhetConsumer.hentBehandlendeEnhet(any(), any()) } returns "4488"
         every { inntektsmeldingRepository.findByUuid(any()) } returns UtsattOppgaveTestData.inntektsmeldingEntitet
     }
@@ -56,7 +56,7 @@ class FinnAlleUtgaandeOppgaverProcessorTest {
                 match { it.tilstand == Tilstand.OpprettetTimeout && !it.speil && it.timeout.isEqual(timeout) && !it.oppdatert.isEqualNullSafe(oppgave.oppdatert) },
             )
         }
-        coVerify { oppgaveService.opprettOppgave(any(), any(), any()) }
+        coVerify { oppgaveService.opprettOppgave(any(), any(), any(), any()) }
     }
 
     @Test
@@ -68,6 +68,6 @@ class FinnAlleUtgaandeOppgaverProcessorTest {
                 match { it.tilstand == Tilstand.Forkastet && !it.speil && it.timeout.isEqual(timeout) && !it.oppdatert.isEqualNullSafe(oppgave.oppdatert) },
             )
         }
-        coVerify(exactly = 0) { oppgaveService.opprettOppgave(any(), any(), any()) }
+        coVerify(exactly = 0) { oppgaveService.opprettOppgave(any(), any(), any(), any()) }
     }
 }

--- a/src/test/kotlin/no/nav/syfo/service/SaksbehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/service/SaksbehandlingServiceTest.kt
@@ -29,7 +29,7 @@ class SaksbehandlingServiceTest {
     @Test
     fun oppretterIkkeOppgaveForSak() {
         runBlocking {
-            coVerify(exactly = 0) { oppgaveService.opprettOppgave(any(), any(), any()) }
+            coVerify(exactly = 0) { oppgaveService.opprettOppgave(any(), any(), any(), any()) }
         }
     }
 

--- a/src/test/kotlin/no/nav/syfo/utsattoppgave/UtsattOppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/utsattoppgave/UtsattOppgaveServiceTest.kt
@@ -43,7 +43,7 @@ class UtsattOppgaveServiceTest {
     fun setup() {
         clearAllMocks()
         every { utsattOppgaveDAO.finn(any()) } returns oppgave
-        coEvery { oppgaveService.opprettOppgave(any(), any(), any()) } returns OppgaveResultat(Random.nextInt(), false, false)
+        coEvery { oppgaveService.opprettOppgave(any(), any(), any(), any()) } returns OppgaveResultat(Random.nextInt(), false, false)
         every { behandlendeEnhetConsumer.hentBehandlendeEnhet(any(), any()) } returns "4488"
         every { inntektsmeldingRepository.findByUuid(any()) } returns UtsattOppgaveTestData.inntektsmeldingEntitet
     }
@@ -65,7 +65,7 @@ class UtsattOppgaveServiceTest {
             )
         utsattOppgaveService.prosesser(oppgaveOppdatering)
         verify { utsattOppgaveDAO.oppdater(match { it.tilstand == Tilstand.Opprettet && it.speil && it.timeout.isEqual(timeout) }) }
-        coVerify { oppgaveService.opprettOppgave(any(), any(), any()) }
+        coVerify { oppgaveService.opprettOppgave(any(), any(), any(), any()) }
     }
 
     @Test
@@ -79,7 +79,7 @@ class UtsattOppgaveServiceTest {
             )
         utsattOppgaveService.prosesser(oppgaveOppdatering)
         verify { utsattOppgaveDAO.oppdater(match { it.tilstand == Tilstand.Opprettet && !it.speil && it.timeout.isEqual(timeout) }) }
-        coVerify { oppgaveService.opprettOppgave(any(), any(), any()) }
+        coVerify { oppgaveService.opprettOppgave(any(), any(), any(), any()) }
     }
 
     @Test
@@ -98,7 +98,7 @@ class UtsattOppgaveServiceTest {
                 match { it.tilstand == Tilstand.Utsatt && it.timeout.isEqual(nyTimeout) && !it.oppdatert.isEqualNullSafe(oppgave.oppdatert) },
             )
         }
-        coVerify(exactly = 0) { oppgaveService.opprettOppgave(any(), any(), any()) }
+        coVerify(exactly = 0) { oppgaveService.opprettOppgave(any(), any(), any(), any()) }
     }
 
     @Test
@@ -116,7 +116,7 @@ class UtsattOppgaveServiceTest {
                 match { it.tilstand == Tilstand.Forkastet && it.timeout.isEqual(timeout) && !it.oppdatert.isEqualNullSafe(oppgave.oppdatert) },
             )
         }
-        coVerify(exactly = 0) { oppgaveService.opprettOppgave(any(), any(), any()) }
+        coVerify(exactly = 0) { oppgaveService.opprettOppgave(any(), any(), any(), any()) }
     }
 
     @Test
@@ -131,7 +131,7 @@ class UtsattOppgaveServiceTest {
             )
         utsattOppgaveService.prosesser(oppgaveOppdatering)
         verify { utsattOppgaveDAO.oppdater(match { it.tilstand == Tilstand.Forkastet && !it.oppdatert.isEqualNullSafe(oppgave.oppdatert) }) }
-        coVerify(exactly = 0) { oppgaveService.opprettOppgave(any(), any(), any()) }
+        coVerify(exactly = 0) { oppgaveService.opprettOppgave(any(), any(), any(), any()) }
     }
 
     @Test
@@ -149,6 +149,6 @@ class UtsattOppgaveServiceTest {
             )
         utsattOppgaveService.prosesser(oppgaveOppdatering)
         verify(exactly = 0) { utsattOppgaveDAO.oppdater(any()) }
-        coVerify(exactly = 0) { oppgaveService.opprettOppgave(any(), any(), any()) }
+        coVerify(exactly = 0) { oppgaveService.opprettOppgave(any(), any(), any(), any()) }
     }
 }


### PR DESCRIPTION
**Problem:**
[Aneth Fossen](https://nav-it.slack.com/archives/D0B5SE9584F) har forespurt at beskrivelsen for inntektsmelding gosys oppgaver inneholder informasjon om saken.  
Dette er slik at saksbehandlere kan vurdere om saken er relevant før de åpner pdf dokumentet.

**Løsning:**
Refaktorisert kode for å tilgjengeligjøre inntektsmeldingen ved opprettelse av gosys oppgaven.
Laget en eget funksjon i sin egen fil `lagInntektsmeldingOppgaveBeskrivelse()`
Bruker `buildList{}` og `add()` for å dynamisk opprette en beskrivelse gitt dataen i inntektsmeldingen