### PR TITLE
oppdater gosys beskrivelse ved refusjon 0 kr

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelse.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.client.oppgave
 
 import no.nav.helsearbeidsgiver.utils.pipe.orDefault
 import no.nav.syfo.domain.inntektsmelding.Inntektsmelding
+import no.nav.syfo.domain.inntektsmelding.Refusjon
 import no.nav.syfo.domain.tilKortFormat
 import no.nav.syfo.domain.tilNorskFormat
 import no.nav.syfo.utsattoppgave.BehandlingsKategori
@@ -9,7 +10,6 @@ import java.math.BigDecimal
 import java.math.RoundingMode
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
-import no.nav.syfo.domain.inntektsmelding.Refusjon
 
 fun lagInntektsmeldingOppgaveBeskrivelse(
     inntektsmelding: Inntektsmelding,

--- a/src/main/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelse.kt
@@ -9,6 +9,7 @@ import java.math.BigDecimal
 import java.math.RoundingMode
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
+import no.nav.syfo.domain.inntektsmelding.Refusjon
 
 fun lagInntektsmeldingOppgaveBeskrivelse(
     inntektsmelding: Inntektsmelding,
@@ -17,9 +18,8 @@ fun lagInntektsmeldingOppgaveBeskrivelse(
     val linjer =
         buildList {
             val refusjon = inntektsmelding.refusjon
-            val erRefusjon = refusjon.beloepPrMnd != null
             val kategori = behandlingsKategori.oppgaveBeskrivelse ?: behandlingsKategori.name
-            add("Refusjon: ${if (erRefusjon) "Ja" else "Nei"} | Kategori: $kategori")
+            add("Refusjon: ${refusjon.formaterTilJaNei()} | Kategori: $kategori")
             add("Inntektsmelding sykepenger")
             add("Utdrag av info, se vedlagt inntektsmelding (PDF) for full informasjon.")
 
@@ -67,6 +67,13 @@ fun lagInntektsmeldingOppgaveBeskrivelse(
 
     return linjer.joinToString("\n")
 }
+
+private fun Refusjon.formaterTilJaNei(): String =
+    when {
+        beloepPrMnd == null -> "Nei"
+        beloepPrMnd.compareTo(BigDecimal.ZERO) == 0 -> "Ja (0 kr)"
+        else -> "Ja"
+    }
 
 private val inntektFormat =
     DecimalFormat(

--- a/src/test/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelseTest.kt
+++ b/src/test/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelseTest.kt
@@ -1,11 +1,11 @@
 package no.nav.syfo.client.oppgave
 
-import java.math.BigDecimal
 import no.nav.syfo.domain.inntektsmelding.Refusjon
 import no.nav.syfo.repository.buildIM
 import no.nav.syfo.utsattoppgave.BehandlingsKategori
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
 
 class ImBeskrivelseTest {
     @Test

--- a/src/test/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelseTest.kt
+++ b/src/test/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelseTest.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.client.oppgave
 
+import java.math.BigDecimal
 import no.nav.syfo.domain.inntektsmelding.Refusjon
 import no.nav.syfo.repository.buildIM
 import no.nav.syfo.utsattoppgave.BehandlingsKategori
@@ -33,6 +34,13 @@ class ImBeskrivelseTest {
             """.trimIndent()
 
         assertEquals(forventet, lagInntektsmeldingOppgaveBeskrivelse(inntektsmelding, BehandlingsKategori.REFUSJON_MED_DATO))
+    }
+
+    @Test
+    fun `beskrivelse med refusjon 0 kr`() {
+        val inntektsmelding = buildIM().copy(refusjon = Refusjon(beloepPrMnd = BigDecimal.ZERO))
+        val beskrivelse = lagInntektsmeldingOppgaveBeskrivelse(inntektsmelding, BehandlingsKategori.REFUSJON_MED_DATO)
+        assert(beskrivelse.contains("Refusjon: Ja (0 kr) | "))
     }
 
     @Test


### PR DESCRIPTION
**Problem:**
Saksbehandler ble forvirret av `Refusjon: Ja` i "tittelen" sammen med `Refusjon: 0 kr/mnd` lenger ned i beskrivelsen

**Løsning:**
Pratet med Aneth som mener det er helt riktig det som allerede står
Men at å sette beløpet til `Ja (0kr)` vil gjøre det litt lettere for saksbehandlere

Eksplisitt legg til `Refusjon: Ja (0 kr)` bare når beløp er 0 kr