### PR TITLE
Gosys beskrivelse refusjon felt blir "Ja (0 kr)" når det skal være "Nei"

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelse.kt
@@ -2,7 +2,6 @@ package no.nav.syfo.client.oppgave
 
 import no.nav.helsearbeidsgiver.utils.pipe.orDefault
 import no.nav.syfo.domain.inntektsmelding.Inntektsmelding
-import no.nav.syfo.domain.inntektsmelding.Refusjon
 import no.nav.syfo.domain.tilKortFormat
 import no.nav.syfo.domain.tilNorskFormat
 import no.nav.syfo.utsattoppgave.BehandlingsKategori
@@ -17,9 +16,8 @@ fun lagInntektsmeldingOppgaveBeskrivelse(
 ): String {
     val linjer =
         buildList {
-            val refusjon = inntektsmelding.refusjon
             val kategori = behandlingsKategori.oppgaveBeskrivelse ?: behandlingsKategori.name
-            add("Refusjon: ${refusjon.formaterTilJaNei()} | Kategori: $kategori")
+            add("Refusjon: ${inntektsmelding.formaterRefusjonTilJaNei()} | Kategori: $kategori")
             add("Inntektsmelding sykepenger")
             add("Utdrag av info, se vedlagt inntektsmelding (PDF) for full informasjon.")
 
@@ -35,6 +33,7 @@ fun lagInntektsmeldingOppgaveBeskrivelse(
             add("")
             inntektsmelding.beregnetInntekt?.let { add("Beregnet månedslønn: ${it.tilNorskFormat()} kr") }
 
+            val refusjon = inntektsmelding.refusjon
             if (refusjon.beloepPrMnd != null) {
                 add("Refusjon: ${refusjon.beloepPrMnd.tilNorskFormat()} kr/mnd")
                 refusjon.opphoersdato?.let { add("Refusjon opphører: ${it.tilNorskFormat()}") }
@@ -68,10 +67,11 @@ fun lagInntektsmeldingOppgaveBeskrivelse(
     return linjer.joinToString("\n")
 }
 
-private fun Refusjon.formaterTilJaNei(): String =
+private fun Inntektsmelding.formaterRefusjonTilJaNei(): String =
     when {
-        beloepPrMnd == null -> "Nei"
-        beloepPrMnd.compareTo(BigDecimal.ZERO) == 0 -> "Ja (0 kr)"
+        this.refusjon.beloepPrMnd == null -> "Nei"
+        this.refusjon.beloepPrMnd.compareTo(BigDecimal.ZERO) == 0 && this.endringerIRefusjon.isEmpty() -> "Nei"
+        this.refusjon.beloepPrMnd.compareTo(BigDecimal.ZERO) == 0 -> "Ja (0 kr)"
         else -> "Ja"
     }
 

--- a/src/test/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelseTest.kt
+++ b/src/test/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelseTest.kt
@@ -1,5 +1,7 @@
 package no.nav.syfo.client.oppgave
 
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.RefusjonEndring
+import no.nav.helsearbeidsgiver.utils.test.date.januar
 import no.nav.syfo.domain.inntektsmelding.Refusjon
 import no.nav.syfo.repository.buildIM
 import no.nav.syfo.simba.mapInntektsmelding
@@ -8,6 +10,7 @@ import no.nav.syfo.utsattoppgave.BehandlingsKategori
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Refusjon as simbaRefusjon
 
 class ImBeskrivelseTest {
     @Test
@@ -51,6 +54,15 @@ class ImBeskrivelseTest {
         val inntektsmelding = mapInntektsmelding(im = simbaIM)
         val beskrivelse = lagInntektsmeldingOppgaveBeskrivelse(inntektsmelding, BehandlingsKategori.REFUSJON_MED_DATO)
         assert(beskrivelse.contains("Refusjon: Nei | "))
+    }
+
+    @Test
+    fun `beskrivelse med refusjon Ja når mappet fra simba im med refusjon endringer`() {
+        val refusjon = simbaRefusjon(0.0, listOf(RefusjonEndring(1.0, 12.januar(2025))))
+        val simbaIM = mockInntektsmelding().copy(refusjon = refusjon)
+        val inntektsmelding = mapInntektsmelding(im = simbaIM)
+        val beskrivelse = lagInntektsmeldingOppgaveBeskrivelse(inntektsmelding, BehandlingsKategori.REFUSJON_MED_DATO)
+        assert(beskrivelse.contains("Refusjon: Ja (0 kr) | "))
     }
 
     @Test

--- a/src/test/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelseTest.kt
+++ b/src/test/kotlin/no/nav/syfo/client/oppgave/ImBeskrivelseTest.kt
@@ -2,6 +2,8 @@ package no.nav.syfo.client.oppgave
 
 import no.nav.syfo.domain.inntektsmelding.Refusjon
 import no.nav.syfo.repository.buildIM
+import no.nav.syfo.simba.mapInntektsmelding
+import no.nav.syfo.simba.mockInntektsmelding
 import no.nav.syfo.utsattoppgave.BehandlingsKategori
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -41,6 +43,14 @@ class ImBeskrivelseTest {
         val inntektsmelding = buildIM().copy(refusjon = Refusjon(beloepPrMnd = BigDecimal.ZERO))
         val beskrivelse = lagInntektsmeldingOppgaveBeskrivelse(inntektsmelding, BehandlingsKategori.REFUSJON_MED_DATO)
         assert(beskrivelse.contains("Refusjon: Ja (0 kr) | "))
+    }
+
+    @Test
+    fun `beskrivelse med refusjon Nei når mappet fra simba im`() {
+        val simbaIM = mockInntektsmelding().copy(refusjon = null)
+        val inntektsmelding = mapInntektsmelding(im = simbaIM)
+        val beskrivelse = lagInntektsmeldingOppgaveBeskrivelse(inntektsmelding, BehandlingsKategori.REFUSJON_MED_DATO)
+        assert(beskrivelse.contains("Refusjon: Nei | "))
     }
 
     @Test


### PR DESCRIPTION
**Problem:**
Fått spørsmål fra saksbehandlere som ser at gosys beskrivelse fra spinosaurus og PDF fra simba viser motsatt info.
Vi har feiltolket im fra simba i denne spinosaurus appen. 
Trodde det er refusjon sak når beløpPerMåned er definert, som har vist seg å være feil.
 
**Løsning:**
BeløpPerMåned blir satt til 0.0 når det ikke er refusjon
Vi kan tolke 0.0 og at det ikke er refusjon endring som `Refusjon: Nei`